### PR TITLE
Add .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,35 @@
+language: cpp
+
+compiler:
+    - gcc
+    - clang
+
+# We cannot use the default gcc, because it's too old and lacks C++11 support.
+
+addons:
+    apt:
+        sources:
+            - ubuntu-toolchain-r-test
+        packages:
+            - g++-4.8
+
+# We have to install cmake manually, because Travis uses version 2.8, which does not work with Vc.
+
+before_install:
+    - wget https://cmake.org/files/v3.3/cmake-3.3.2-Linux-x86_64.tar.gz --no-check-certificate
+    - tar xf cmake-3.3.2-Linux-x86_64.tar.gz
+
+install:
+    - export CMAKE=$(readlink -f "cmake-3.3.2-Linux-x86_64/bin/cmake")
+    - if [ "$CXX" = "g++" ]; then export CXX="g++-4.8" CC="gcc-4.8"; fi
+
+before_script:
+    - $CMAKE --version
+    - mkdir build
+    - cd build
+    - $CMAKE ..
+
+script:
+    - $CXX --version
+    - make -j2
+    - make test -j2

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ before_install:
 
 install:
     - export CMAKE=$(readlink -f "cmake-3.3.2-Linux-x86_64/bin/cmake")
+    - export CTEST=$(readlink -f "cmake-3.3.2-Linux-x86_64/bin/ctest")
     - if [ "$CXX" = "g++" ]; then export CXX="g++-4.8" CC="gcc-4.8"; fi
 
 before_script:
@@ -32,4 +33,4 @@ before_script:
 script:
     - $CXX --version
     - make -j2
-    - make test -j2
+    - $CTEST -j2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: cpp
 
+os:
+    - linux
+    - osx
+
 compiler:
     - gcc
     - clang
@@ -16,13 +20,19 @@ addons:
 # We have to install cmake manually, because Travis uses version 2.8, which does not work with Vc.
 
 before_install:
-    - wget https://cmake.org/files/v3.3/cmake-3.3.2-Linux-x86_64.tar.gz --no-check-certificate
-    - tar xf cmake-3.3.2-Linux-x86_64.tar.gz
+    - if [ "$TRAVIS_OS_NAME" = "linux" ]; then wget https://cmake.org/files/v3.3/cmake-3.3.2-Linux-x86_64.tar.gz --no-check-certificate -O cmake.tar.gz; fi
+    - if [ "$TRAVIS_OS_NAME" = "osx" ]; then wget https://cmake.org/files/v3.3/cmake-3.3.2-Darwin-x86_64.tar.gz --no-check-certificate -O cmake.tar.gz; fi
+    - tar xf cmake.tar.gz
+    - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew update; fi
 
 install:
-    - export CMAKE=$(readlink -f "cmake-3.3.2-Linux-x86_64/bin/cmake")
-    - export CTEST=$(readlink -f "cmake-3.3.2-Linux-x86_64/bin/ctest")
-    - if [ "$CXX" = "g++" ]; then export CXX="g++-4.8" CC="gcc-4.8"; fi
+    - if [ "$TRAVIS_OS_NAME" = "linux" ]; then export CMAKE=$(readlink -f "cmake-3.3.2-Linux-x86_64/bin/cmake"); fi
+    - if [ "$TRAVIS_OS_NAME" = "linux" ]; then export CTEST=$(readlink -f "cmake-3.3.2-Linux-x86_64/bin/ctest"); fi
+    - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew install coreutils; fi
+    - if [ "$TRAVIS_OS_NAME" = "osx" ]; then export CMAKE=$(greadlink -f "cmake-3.3.2-Darwin-x86_64/CMake.app/Contents/bin/cmake"); fi
+    - if [ "$TRAVIS_OS_NAME" = "osx" ]; then export CTEST=$(greadlink -f "cmake-3.3.2-Darwin-x86_64/CMake.app/Contents/bin/ctest"); fi
+    - if [ "$TRAVIS_OS_NAME" = "linux" ] && [ "$CXX" = "g++" ]; then export CXX="g++-4.8" CC="gcc-4.8"; fi
+    - if [ "$TRAVIS_OS_NAME" = "osx" ] && [ "$CXX" = "g++" ]; then export CXX="g++-4.9" CC="gcc-4.9"; fi
 
 before_script:
     - $CMAKE --version


### PR DESCRIPTION
This should enable automatic Travis CI builds with gcc 4.8 and clang 3.4.

To make it work, you will need to go to https://travis-ci.org/ and enable Travis for your Vc repository.

Other compiler versions and compilers can also be implemented with a bit of work.