### PR TITLE
test case for failing construction of Vc::SimdArray<int,2>

### DIFF
--- a/tests/simdarray.cpp
+++ b/tests/simdarray.cpp
@@ -226,3 +226,20 @@ TEST_TYPES(V, store, SIMD_ARRAY_LIST)
     a.store(&data[1], Vc::Unaligned | Vc::Streaming);
     for (size_t i = 0; i < V::Size; ++i) COMPARE(data[i + 1], T(i));
 }
+
+
+TEST(load_from_int_array)
+{
+    int array[8]={1,2,3,4,5,6,7,8};
+    {
+      typedef Vc::SimdArray<int, 4> I4_t; // a 4 element int
+      I4_t a(array);
+      for (size_t i = 0; i < I4_t::Size; ++i) COMPARE(a[i], array[i]);
+    }
+    {
+      typedef Vc::SimdArray<int, 2> I2_t; // a 2 element int
+      I2_t a(array);
+      for (size_t i = 0; i < I2_t::Size; ++i) COMPARE(a[i], array[i]);
+    }
+}
+


### PR DESCRIPTION
providing test case for failing construction of a "small" Vc::SimdArray<int, 2> from an ordinary int array.
Shall I open a github issue, too?