### PR TITLE
Use CheckIncludeFileCXX instead of CheckIncludeFile

### DIFF
--- a/cmake/OptimizeForArchitecture.cmake
+++ b/cmake/OptimizeForArchitecture.cmake
@@ -46,7 +46,7 @@
 
 get_filename_component(_currentDir "${CMAKE_CURRENT_LIST_FILE}" PATH)
 include("${_currentDir}/AddCompilerFlag.cmake")
-include(CheckIncludeFile)
+include(CheckIncludeFileCXX)
 
 macro(_my_find _list _value _ret)
    list(FIND ${_list} "${_value}" _found)
@@ -519,7 +519,7 @@ Other supported values are: \"none\", \"generic\", \"core\", \"merom\" (65nm Cor
                set(_resultVar "HAVE_${_header}")
                string(REPLACE "." "_" _resultVar "${_resultVar}")
                if(_header)
-                  CHECK_INCLUDE_FILE("${_header}" ${_resultVar} "-m${_flag}")
+                  CHECK_INCLUDE_FILE_CXX("${_header}" ${_resultVar} "-m${_flag}")
                   if(NOT ${_resultVar})
                      set(_useVar "USE_${_flag}")
                      string(TOUPPER "${_useVar}" _useVar)


### PR DESCRIPTION
CheckIncludeFile uses the C compiler instead of the C++ compiler to check headers. Using it also requires the calling project to enable C.