### PR TITLE
Install cmake config files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -214,6 +214,17 @@ set(cmake_install_files
    cmake/FindMIC.cmake
    )
 
+install(FILES
+    ${CMAKE_CURRENT_BINARY_DIR}/cmake/VcConfig.cmake
+    ${CMAKE_CURRENT_BINARY_DIR}/cmake/VcConfigVersion.cmake
+    DESTINATION cmake
+    )
+
+install(FILES
+    ${cmake_install_files}
+    DESTINATION cmake/Vc/
+    )
+
 #Release# option(BUILD_TESTING "Build the testing tree." OFF)
 include (CTest)
 configure_file(${CMAKE_SOURCE_DIR}/CTestCustom.cmake ${CMAKE_BINARY_DIR}/CTestCustom.cmake COPYONLY)


### PR DESCRIPTION
Note: this does still not enable me to find Vc for some reason, so this
patch is no good and just a basis for discussion.
I'm a bit unsure how the file structure should be to work.

find_package(Vc 1.2.0)

gives me:
-- Using CMake version: 3.6.2
CMake Error at /opt/Vc/cmake/VcConfig.cmake:17 (include):
  include could not find load file:

    Vc_CMAKE_MODULES_DIR-NOTFOUND/VcMacros.cmake
Call Stack (most recent call first):
  /home/frederik/dev/kde/krita/cmake/modules/FindVc.cmake:29 (find_package)
  CMakeLists.txt:15 (find_package)


CMake Error at /opt/Vc/cmake/VcConfig.cmake:22 (vc_set_preferred_compiler_flags):
  Unknown CMake command "vc_set_preferred_compiler_flags".
Call Stack (most recent call first):
  /home/frederik/dev/kde/krita/cmake/modules/FindVc.cmake:29 (find_package)
  CMakeLists.txt:15 (find_package)


-- Configuring incomplete, errors occurred!
