### PR TITLE
cmake: match amd64 for x86 support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,7 +132,7 @@ if(MIC_FOUND)
 endif()
 
 set(_srcs src/const.cpp)
-if("${CMAKE_SYSTEM_PROCESSOR}" MATCHES "([x3-7]86|AMD64)")
+if("${CMAKE_SYSTEM_PROCESSOR}" MATCHES "([x3-7]86|AMD64|amd64)")
 
    list(APPEND _srcs src/cpuid.cpp src/support_x86.cpp)
    vc_compile_for_all_implementations(_srcs src/trigonometric.cpp ONLY SSE2 SSE3 SSSE3 SSE4_1 AVX SSE+XOP+FMA4 AVX+XOP+FMA4 AVX+XOP+FMA AVX+FMA AVX2+FMA+BMI2)


### PR DESCRIPTION
This is used on kFreeBSD, and possibly by FreeBSD as well.