### PR TITLE
allow move of ElementReference

### DIFF
--- a/avx/mask.h
+++ b/avx/mask.h
@@ -190,6 +190,12 @@ private:
     }
 
 public:
+    /**
+     * \note the returned object models the concept of a reference and
+     * as such it can exist longer than the data it is referencing.
+     * \note to avoid lifetime issues, we strongly advice not to store
+     * any reference objects.
+     */
     Vc_ALWAYS_INLINE reference operator[](size_t index) noexcept
     {
         return {*this, int(index)};

--- a/avx/vector.h
+++ b/avx/vector.h
@@ -274,6 +274,12 @@ public:
         }
 
     public:
+        /**
+         * \note the returned object models the concept of a reference and
+         * as such it can exist longer than the data it is referencing.
+         * \note to avoid lifetime issues, we strongly advice not to store
+         * any reference objects.
+         */
         Vc_ALWAYS_INLINE reference operator[](size_t index) noexcept
         {
             static_assert(noexcept(reference{std::declval<Vector &>(), int()}), "");

--- a/common/elementreference.h
+++ b/common/elementreference.h
@@ -51,6 +51,25 @@ template <typename U, typename Accessor = U> class ElementReference
 public:
     Vc_INTRINSIC ElementReference(const ElementReference &) = delete;
 
+    /**
+     * Move Constructor
+     *
+     * this is the only way to constructor an ElementReference in user code
+     *
+     * \note
+     * Please be aware that this class models the concept of a reference
+     * and as such it can have the same lifetime issue as a standard C++
+     * reference.
+     *
+     * \note
+     * C++ 17 support copy-elision, which in turn allows to
+     * the ElementReference obtained via operator[] from a function
+     * and avoid copying. C++11 and C++14 don't offer this, thus we add
+     * the move constructor, to allow them to move the data and thus avoid
+     * copying (which was prohibited by the deleted constructor above
+     */
+    Vc_INTRINSIC ElementReference(ElementReference &&) = default;
+
     Vc_INTRINSIC operator value_type() const noexcept(get_noexcept)
     {
         return Accessor::get(obj, index);

--- a/common/simdarray.h
+++ b/common/simdarray.h
@@ -348,6 +348,12 @@ private:
     }
 
 public:
+    /**
+     * \note the returned object models the concept of a reference and
+     * as such it can exist longer than the data it is referencing.
+     * \note to avoid lifetime issues, we strongly advice not to store
+     * any reference objects.
+     */
     Vc_INTRINSIC reference operator[](size_t i) noexcept
     {
         static_assert(noexcept(reference{std::declval<SimdArray &>(), int()}), "");
@@ -954,6 +960,12 @@ private:
 
 public:
     ///\copydoc Vector::operator[](size_t)
+    /**
+     * \note the returned object models the concept of a reference and
+     * as such it can exist longer than the data it is referencing.
+     * \note to avoid lifetime issues, we strongly advice not to store
+     * any reference objects.
+     */
     Vc_INTRINSIC reference operator[](size_t i) noexcept
     {
         static_assert(noexcept(reference{std::declval<SimdArray &>(), int()}), "");
@@ -1665,7 +1677,7 @@ Vc_ALL_COMPARES(Vc_BINARY_OPERATORS_);
 
 /**
  * \name Math functions
- * These functions evaluate the 
+ * These functions evaluate the
  */
 ///@{
 Vc_FORWARD_UNARY_OPERATOR(abs);

--- a/common/simdarrayhelper.h
+++ b/common/simdarrayhelper.h
@@ -135,7 +135,7 @@ template <typename T_, std::size_t Pieces_, std::size_t Index_> struct Segment/*
 
     static constexpr std::size_t EntryOffset = Index * type_decayed::Size / Pieces;
 
-    // no non-const operator[] needed (and problematic because of non-movable ElementReference)
+    // no non-const operator[] needed
     decltype(std::declval<const type &>()[0]) operator[](size_t i) const { return data[i + EntryOffset]; }
 
     simd_array_type asSimdArray() const

--- a/common/simdmaskarray.h
+++ b/common/simdmaskarray.h
@@ -218,6 +218,12 @@ private:
     }
 
 public:
+    /**
+     * \note the returned object models the concept of a reference and
+     * as such it can exist longer than the data it is referencing.
+     * \note to avoid lifetime issues, we strongly advice not to store
+     * any reference objects.
+     */
     Vc_INTRINSIC Vc_PURE reference operator[](size_t index) noexcept
     {
         return {data, int(index)};

--- a/common/vector.h
+++ b/common/vector.h
@@ -348,6 +348,10 @@ public:
      * \warning The use of this function may result in suboptimal performance. Please
      *          check whether you can find a more vector-friendly way to do what you
      *          intended.
+     * \note the returned object models the concept of a reference and
+     * as such it can exist longer than the data it is referencing.
+     * \note to avoid lifetime issues, we strongly advice not to store
+     * any reference objects.
      */
     inline reference operator[](size_t index) noexcept;
     /**

--- a/mic/mask.h
+++ b/mic/mask.h
@@ -208,6 +208,12 @@ private:
     }
 
 public:
+    /**
+     * \note the returned object models the concept of a reference and
+     * as such it can exist longer than the data it is referencing.
+     * \note to avoid lifetime issues, we strongly advice not to store
+     * any reference objects.
+     */
     Vc_ALWAYS_INLINE reference operator[](size_t index) noexcept
     {
         return {*this, int(index)};

--- a/mic/vector.h
+++ b/mic/vector.h
@@ -217,6 +217,12 @@ private:
     }
 
 public:
+    /**
+     * \note the returned object models the concept of a reference and
+     * as such it can exist longer than the data it is referencing.
+     * \note to avoid lifetime issues, we strongly advice not to store
+     * any reference objects.
+     */
     Vc_ALWAYS_INLINE reference operator[](size_t index) noexcept
     {
         static_assert(noexcept(reference{std::declval<Vector &>(), int()}), "");

--- a/scalar/mask.h
+++ b/scalar/mask.h
@@ -139,6 +139,12 @@ private:
     }
 
 public:
+    /**
+     * \note the returned object models the concept of a reference and
+     * as such it can exist longer than the data it is referencing.
+     * \note to avoid lifetime issues, we strongly advice not to store
+     * any reference objects.
+     */
     Vc_ALWAYS_INLINE reference operator[](size_t i) noexcept
     {
         Vc_ASSERT(i == 0); if (i) {}

--- a/scalar/vector.h
+++ b/scalar/vector.h
@@ -154,6 +154,12 @@ template <typename T> class Vector<T, VectorAbi::Scalar>
         }
 
     public:
+        /**
+         * \note the returned object models the concept of a reference and
+         * as such it can exist longer than the data it is referencing.
+         * \note to avoid lifetime issues, we strongly advice not to store
+         * any reference objects.
+         */
         Vc_ALWAYS_INLINE reference operator[](size_t index) noexcept
         {
             static_assert(noexcept(reference{std::declval<Vector &>(), int()}), "");

--- a/sse/mask.h
+++ b/sse/mask.h
@@ -221,6 +221,12 @@ private:
     }
 
 public:
+    /**
+     * \note the returned object models the concept of a reference and
+     * as such it can exist longer than the data it is referencing.
+     * \note to avoid lifetime issues, we strongly advice not to store
+     * any reference objects.
+     */
     Vc_ALWAYS_INLINE reference operator[](size_t index) noexcept
     {
         return {*this, int(index)};

--- a/sse/vector.h
+++ b/sse/vector.h
@@ -172,6 +172,12 @@ template <typename T> class Vector<T, VectorAbi::Sse>
         }
 
     public:
+        /**
+         * \note the returned object models the concept of a reference and
+         * as such it can exist longer than the data it is referencing.
+         * \note to avoid lifetime issues, we strongly advice not to store
+         * any reference objects.
+         */
         Vc_ALWAYS_INLINE reference operator[](size_t index) noexcept
         {
             static_assert(noexcept(reference{std::declval<Vector &>(), int()}), "");

--- a/tests/scalaraccess.cpp
+++ b/tests/scalaraccess.cpp
@@ -49,7 +49,7 @@ TEST_TYPES(V, reads, (ALL_VECTORS, SIMD_ARRAY_LIST))
     // The non-const operator[] returns a smart reference that mimics an lvalue reference.
     // But since it's not an actual lvalue reference the proxy is supposed to live as
     // short as possible. To achieve this all move & copy operations must be disabled.
-    VERIFY(!std::is_move_constructible<decltype(a[0])>::value);
+    VERIFY(std::is_move_constructible<decltype(a[0])>::value);
     VERIFY(!std::is_copy_constructible<decltype(a[0])>::value);
     VERIFY(!std::is_move_assignable<decltype(a[0])>::value);
     VERIFY(!std::is_copy_assignable<decltype(a[0])>::value);


### PR DESCRIPTION
- add a move constructor to ElementReference
- add documentation to operator[] to explain about prossible problems
  regarding life time of the returned reference

see VcDevel/Vc#168