### PR TITLE
Vectorizable

### DIFF
--- a/avx/types.h
+++ b/avx/types.h
@@ -74,6 +74,23 @@ template <typename T> struct is_vector : public std::false_type {};
 template <typename T> struct is_vector<Vector<T>> : public std::true_type {};
 template <typename T> struct is_mask : public std::false_type {};
 template <typename T> struct is_mask<Mask<T>> : public std::true_type {};
+
+template <class T> struct is_valid_vector_argument
+  : public std::false_type {};
+
+template <> struct is_valid_vector_argument<double>
+  : public std::true_type {};
+template <> struct is_valid_vector_argument<float>
+  : public std::true_type {};
+template <> struct is_valid_vector_argument<int>
+  : public std::true_type {};
+template <> struct is_valid_vector_argument<uint>
+  : public std::true_type {};
+template <> struct is_valid_vector_argument<short>
+  : public std::true_type {};
+template <> struct is_valid_vector_argument<ushort>
+  : public std::true_type {};
+
 }  // namespace AVX
 
 namespace AVX2
@@ -104,10 +121,7 @@ template <typename T> struct is_vector : public std::false_type {};
 template <typename T> struct is_vector<Vector<T>> : public std::true_type {};
 template <typename T> struct is_mask : public std::false_type {};
 template <typename T> struct is_mask<Mask<T>> : public std::true_type {};
-}  // namespace AVX2
 
-namespace Traits
-{
 template <class T> struct is_valid_vector_argument
   : public std::false_type {};
 
@@ -124,9 +138,13 @@ template <> struct is_valid_vector_argument<short>
 template <> struct is_valid_vector_argument<ushort>
   : public std::true_type {};
 
+}  // namespace AVX2
+
+namespace Traits
+{
 template <class T> struct
 is_simd_vector_internal<Vector<T, VectorAbi::Avx>>
-  : public is_valid_vector_argument<T> {};
+  : public AVX::is_valid_vector_argument<T> {};
 
 template<typename T> struct is_simd_mask_internal<Mask<T, VectorAbi::Avx>>
   : public std::true_type {};

--- a/avx/types.h
+++ b/avx/types.h
@@ -108,8 +108,28 @@ template <typename T> struct is_mask<Mask<T>> : public std::true_type {};
 
 namespace Traits
 {
-template<typename T> struct is_simd_mask_internal<Mask<T, VectorAbi::Avx>> : public std::true_type {};
-template<typename T> struct is_simd_vector_internal<Vector<T, VectorAbi::Avx>> : public std::true_type {};
+template <class T> struct is_valid_vector_argument
+  : public std::false_type {};
+
+template <> struct is_valid_vector_argument<double>
+  : public std::true_type {};
+template <> struct is_valid_vector_argument<float>
+  : public std::true_type {};
+template <> struct is_valid_vector_argument<int>
+  : public std::true_type {};
+template <> struct is_valid_vector_argument<uint>
+  : public std::true_type {};
+template <> struct is_valid_vector_argument<short>
+  : public std::true_type {};
+template <> struct is_valid_vector_argument<ushort>
+  : public std::true_type {};
+
+template <class T> struct
+is_simd_vector_internal<Vector<T, VectorAbi::Avx>>
+  : public is_valid_vector_argument<T> {};
+
+template<typename T> struct is_simd_mask_internal<Mask<T, VectorAbi::Avx>>
+  : public std::true_type {};
 }  // namespace Traits
 }  // namespace Vc
 

--- a/avx/types.h
+++ b/avx/types.h
@@ -75,22 +75,14 @@ template <typename T> struct is_vector<Vector<T>> : public std::true_type {};
 template <typename T> struct is_mask : public std::false_type {};
 template <typename T> struct is_mask<Mask<T>> : public std::true_type {};
 
-template <class T> struct is_valid_vector_argument
-  : public std::false_type {};
+template<typename T> struct is_valid_vector_argument  : public std::false_type {};
 
-template <> struct is_valid_vector_argument<double>
-  : public std::true_type {};
-template <> struct is_valid_vector_argument<float>
-  : public std::true_type {};
-template <> struct is_valid_vector_argument<int>
-  : public std::true_type {};
-template <> struct is_valid_vector_argument<uint>
-  : public std::true_type {};
-template <> struct is_valid_vector_argument<short>
-  : public std::true_type {};
-template <> struct is_valid_vector_argument<ushort>
-  : public std::true_type {};
-
+template <> struct is_valid_vector_argument<double> : public std::true_type {};
+template <> struct is_valid_vector_argument<float>  : public std::true_type {};
+template <> struct is_valid_vector_argument<int>    : public std::true_type {};
+template <> struct is_valid_vector_argument<uint>   : public std::true_type {};
+template <> struct is_valid_vector_argument<short>  : public std::true_type {};
+template <> struct is_valid_vector_argument<ushort> : public std::true_type {};
 }  // namespace AVX
 
 namespace AVX2
@@ -122,22 +114,14 @@ template <typename T> struct is_vector<Vector<T>> : public std::true_type {};
 template <typename T> struct is_mask : public std::false_type {};
 template <typename T> struct is_mask<Mask<T>> : public std::true_type {};
 
-template <class T> struct is_valid_vector_argument
-  : public std::false_type {};
+template<typename T> struct is_valid_vector_argument  : public std::false_type {};
 
-template <> struct is_valid_vector_argument<double>
-  : public std::true_type {};
-template <> struct is_valid_vector_argument<float>
-  : public std::true_type {};
-template <> struct is_valid_vector_argument<int>
-  : public std::true_type {};
-template <> struct is_valid_vector_argument<uint>
-  : public std::true_type {};
-template <> struct is_valid_vector_argument<short>
-  : public std::true_type {};
-template <> struct is_valid_vector_argument<ushort>
-  : public std::true_type {};
-
+template <> struct is_valid_vector_argument<double> : public std::true_type {};
+template <> struct is_valid_vector_argument<float>  : public std::true_type {};
+template <> struct is_valid_vector_argument<int>    : public std::true_type {};
+template <> struct is_valid_vector_argument<uint>   : public std::true_type {};
+template <> struct is_valid_vector_argument<short>  : public std::true_type {};
+template <> struct is_valid_vector_argument<ushort> : public std::true_type {};
 }  // namespace AVX2
 
 namespace Traits

--- a/avx/types.h
+++ b/avx/types.h
@@ -74,15 +74,6 @@ template <typename T> struct is_vector : public std::false_type {};
 template <typename T> struct is_vector<Vector<T>> : public std::true_type {};
 template <typename T> struct is_mask : public std::false_type {};
 template <typename T> struct is_mask<Mask<T>> : public std::true_type {};
-
-template<typename T> struct is_valid_vector_argument  : public std::false_type {};
-
-template <> struct is_valid_vector_argument<double> : public std::true_type {};
-template <> struct is_valid_vector_argument<float>  : public std::true_type {};
-template <> struct is_valid_vector_argument<int>    : public std::true_type {};
-template <> struct is_valid_vector_argument<uint>   : public std::true_type {};
-template <> struct is_valid_vector_argument<short>  : public std::true_type {};
-template <> struct is_valid_vector_argument<ushort> : public std::true_type {};
 }  // namespace AVX
 
 namespace AVX2
@@ -113,22 +104,13 @@ template <typename T> struct is_vector : public std::false_type {};
 template <typename T> struct is_vector<Vector<T>> : public std::true_type {};
 template <typename T> struct is_mask : public std::false_type {};
 template <typename T> struct is_mask<Mask<T>> : public std::true_type {};
-
-template<typename T> struct is_valid_vector_argument  : public std::false_type {};
-
-template <> struct is_valid_vector_argument<double> : public std::true_type {};
-template <> struct is_valid_vector_argument<float>  : public std::true_type {};
-template <> struct is_valid_vector_argument<int>    : public std::true_type {};
-template <> struct is_valid_vector_argument<uint>   : public std::true_type {};
-template <> struct is_valid_vector_argument<short>  : public std::true_type {};
-template <> struct is_valid_vector_argument<ushort> : public std::true_type {};
 }  // namespace AVX2
 
 namespace Traits
 {
 template <class T> struct
 is_simd_vector_internal<Vector<T, VectorAbi::Avx>>
-  : public AVX::is_valid_vector_argument<T> {};
+  : public is_valid_vector_argument<T> {};
 
 template<typename T> struct is_simd_mask_internal<Mask<T, VectorAbi::Avx>>
   : public std::true_type {};

--- a/mic/types.h
+++ b/mic/types.h
@@ -67,12 +67,27 @@ template <typename T> struct is_vector : public std::false_type {};
 template <typename T> struct is_vector<Vector<T>> : public std::true_type {};
 template <typename T> struct is_mask : public std::false_type {};
 template <typename T> struct is_mask<Mask<T>> : public std::true_type {};
+
+template<typename T> struct is_valid_vector_argument  : public std::false_type {};
+
+template <> struct is_valid_vector_argument<double> : public std::true_type {};
+template <> struct is_valid_vector_argument<float>  : public std::true_type {};
+template <> struct is_valid_vector_argument<int>    : public std::true_type {};
+template <> struct is_valid_vector_argument<uint>   : public std::true_type {};
+template <> struct is_valid_vector_argument<short>  : public std::true_type {};
+template <> struct is_valid_vector_argument<ushort> : public std::true_type {};
+template <> struct is_valid_vector_argument<schar>  : public std::true_type {};
+template <> struct is_valid_vector_argument<uchar>  : public std::true_type {};
 }  // namespace MIC
 
 namespace Traits
 {
-template <typename T> struct is_simd_mask_internal<MIC::Mask<T>> : public std::true_type {};
-template <typename T> struct is_simd_vector_internal<MIC::Vector<T>> : public std::true_type {};
+template <typename T> struct is_simd_mask_internal<MIC::Mask<T>>
+  : public std::true_type {};
+
+template <typename T> struct
+is_simd_vector_internal<Vector<T, VectorAbi::Mic>>
+  : public MIC::is_valid_vector_argument<T> {};
 }  // namespace Traits
 }  // namespace Vc
 

--- a/mic/types.h
+++ b/mic/types.h
@@ -67,17 +67,6 @@ template <typename T> struct is_vector : public std::false_type {};
 template <typename T> struct is_vector<Vector<T>> : public std::true_type {};
 template <typename T> struct is_mask : public std::false_type {};
 template <typename T> struct is_mask<Mask<T>> : public std::true_type {};
-
-template<typename T> struct is_valid_vector_argument  : public std::false_type {};
-
-template <> struct is_valid_vector_argument<double> : public std::true_type {};
-template <> struct is_valid_vector_argument<float>  : public std::true_type {};
-template <> struct is_valid_vector_argument<int>    : public std::true_type {};
-template <> struct is_valid_vector_argument<uint>   : public std::true_type {};
-template <> struct is_valid_vector_argument<short>  : public std::true_type {};
-template <> struct is_valid_vector_argument<ushort> : public std::true_type {};
-template <> struct is_valid_vector_argument<schar>  : public std::true_type {};
-template <> struct is_valid_vector_argument<uchar>  : public std::true_type {};
 }  // namespace MIC
 
 namespace Traits
@@ -87,7 +76,7 @@ template <typename T> struct is_simd_mask_internal<MIC::Mask<T>>
 
 template <typename T> struct
 is_simd_vector_internal<Vector<T, VectorAbi::Mic>>
-  : public MIC::is_valid_vector_argument<T> {};
+  : public is_valid_vector_argument<T> {};
 }  // namespace Traits
 }  // namespace Vc
 

--- a/scalar/types.h
+++ b/scalar/types.h
@@ -63,15 +63,6 @@ template <typename T> struct is_vector : public std::false_type {};
 template <typename T> struct is_vector<Vector<T>> : public std::true_type {};
 template <typename T> struct is_mask : public std::false_type {};
 template <typename T> struct is_mask<Mask<T>> : public std::true_type {};
-
-template<typename T> struct is_valid_vector_argument  : public std::false_type {};
-
-template <> struct is_valid_vector_argument<double> : public std::true_type {};
-template <> struct is_valid_vector_argument<float>  : public std::true_type {};
-template <> struct is_valid_vector_argument<int>    : public std::true_type {};
-template <> struct is_valid_vector_argument<uint>   : public std::true_type {};
-template <> struct is_valid_vector_argument<short>  : public std::true_type {};
-template <> struct is_valid_vector_argument<ushort> : public std::true_type {};
 }  // namespace Scalar
 
 namespace Traits
@@ -81,7 +72,7 @@ template <typename T> struct is_simd_mask_internal<Scalar::Mask<T>>
 
 template <class T> struct
 is_simd_vector_internal<Vector<T, VectorAbi::Scalar>>
-  : public Scalar::is_valid_vector_argument<T> {};
+  : public is_valid_vector_argument<T> {};
 }  // namespace Traits
 }  // namespace Vc
 

--- a/scalar/types.h
+++ b/scalar/types.h
@@ -63,12 +63,25 @@ template <typename T> struct is_vector : public std::false_type {};
 template <typename T> struct is_vector<Vector<T>> : public std::true_type {};
 template <typename T> struct is_mask : public std::false_type {};
 template <typename T> struct is_mask<Mask<T>> : public std::true_type {};
+
+template<typename T> struct is_valid_vector_argument  : public std::false_type {};
+
+template <> struct is_valid_vector_argument<double> : public std::true_type {};
+template <> struct is_valid_vector_argument<float>  : public std::true_type {};
+template <> struct is_valid_vector_argument<int>    : public std::true_type {};
+template <> struct is_valid_vector_argument<uint>   : public std::true_type {};
+template <> struct is_valid_vector_argument<short>  : public std::true_type {};
+template <> struct is_valid_vector_argument<ushort> : public std::true_type {};
 }  // namespace Scalar
 
 namespace Traits
 {
-template <typename T> struct is_simd_mask_internal<Scalar::Mask<T>> : public std::true_type {};
-template <typename T> struct is_simd_vector_internal<Scalar::Vector<T>> : public std::true_type {};
+template <typename T> struct is_simd_mask_internal<Scalar::Mask<T>>
+  : public std::true_type {};
+
+template <class T> struct
+is_simd_vector_internal<Vector<T, VectorAbi::Scalar>>
+  : public Scalar::is_valid_vector_argument<T> {};
 }  // namespace Traits
 }  // namespace Vc
 

--- a/sse/types.h
+++ b/sse/types.h
@@ -66,24 +66,14 @@ template <typename T> struct is_vector<Vector<T>> : public std::true_type {};
 template <typename T> struct is_mask : public std::false_type {};
 template <typename T> struct is_mask<Mask<T>> : public std::true_type {};
 
-template <class T> struct is_valid_vector_argument
-  : public std::false_type {};
+template<typename T> struct is_valid_vector_argument  : public std::false_type {};
 
-template <> struct is_valid_vector_argument<double>
-  : public std::true_type {};
-template <> struct is_valid_vector_argument<float>
-  : public std::true_type {};
-template <> struct is_valid_vector_argument<int>
-  : public std::true_type {};
-template <> struct is_valid_vector_argument<uint>
-  : public std::true_type {};
-template <> struct is_valid_vector_argument<short>
-  : public std::true_type {};
-template <> struct is_valid_vector_argument<ushort>
-  : public std::true_type {};
-
-  
-
+template <> struct is_valid_vector_argument<double> : public std::true_type {};
+template <> struct is_valid_vector_argument<float>  : public std::true_type {};
+template <> struct is_valid_vector_argument<int>    : public std::true_type {};
+template <> struct is_valid_vector_argument<uint>   : public std::true_type {};
+template <> struct is_valid_vector_argument<short>  : public std::true_type {};
+template <> struct is_valid_vector_argument<ushort> : public std::true_type {};
 }  // namespace SSE
 
 namespace Traits
@@ -91,7 +81,6 @@ namespace Traits
 template <class T> struct
 is_simd_vector_internal<Vector<T, VectorAbi::Sse>>
   : public SSE::is_valid_vector_argument<T> {};
-
 
 template<typename T> struct is_simd_mask_internal<Mask<T, VectorAbi::Sse>>
   : public std::true_type {};

--- a/sse/types.h
+++ b/sse/types.h
@@ -69,8 +69,29 @@ template <typename T> struct is_mask<Mask<T>> : public std::true_type {};
 
 namespace Traits
 {
-template <typename T> struct is_simd_mask_internal<SSE::Mask<T>> : public std::true_type {};
-template <typename T> struct is_simd_vector_internal<SSE::Vector<T>> : public std::true_type {};
+template <class T> struct is_valid_vector_argument
+  : public std::false_type {};
+
+template <> struct is_valid_vector_argument<double>
+  : public std::true_type {};
+template <> struct is_valid_vector_argument<float>
+  : public std::true_type {};
+template <> struct is_valid_vector_argument<int>
+  : public std::true_type {};
+template <> struct is_valid_vector_argument<uint>
+  : public std::true_type {};
+template <> struct is_valid_vector_argument<short>
+  : public std::true_type {};
+template <> struct is_valid_vector_argument<ushort>
+  : public std::true_type {};
+
+template <class T> struct
+is_simd_vector_internal<Vector<T, VectorAbi::Sse>>
+  : public is_valid_vector_argument<T> {};
+
+
+template<typename T> struct is_simd_mask_internal<Mask<T, VectorAbi::Sse>>
+  : public std::true_type {};
 }  // namespace Traits
 }  // namespace Vc
 

--- a/sse/types.h
+++ b/sse/types.h
@@ -65,10 +65,7 @@ template <typename T> struct is_vector : public std::false_type {};
 template <typename T> struct is_vector<Vector<T>> : public std::true_type {};
 template <typename T> struct is_mask : public std::false_type {};
 template <typename T> struct is_mask<Mask<T>> : public std::true_type {};
-}  // namespace SSE
 
-namespace Traits
-{
 template <class T> struct is_valid_vector_argument
   : public std::false_type {};
 
@@ -85,9 +82,15 @@ template <> struct is_valid_vector_argument<short>
 template <> struct is_valid_vector_argument<ushort>
   : public std::true_type {};
 
+  
+
+}  // namespace SSE
+
+namespace Traits
+{
 template <class T> struct
 is_simd_vector_internal<Vector<T, VectorAbi::Sse>>
-  : public is_valid_vector_argument<T> {};
+  : public SSE::is_valid_vector_argument<T> {};
 
 
 template<typename T> struct is_simd_mask_internal<Mask<T, VectorAbi::Sse>>

--- a/sse/types.h
+++ b/sse/types.h
@@ -65,22 +65,13 @@ template <typename T> struct is_vector : public std::false_type {};
 template <typename T> struct is_vector<Vector<T>> : public std::true_type {};
 template <typename T> struct is_mask : public std::false_type {};
 template <typename T> struct is_mask<Mask<T>> : public std::true_type {};
-
-template<typename T> struct is_valid_vector_argument  : public std::false_type {};
-
-template <> struct is_valid_vector_argument<double> : public std::true_type {};
-template <> struct is_valid_vector_argument<float>  : public std::true_type {};
-template <> struct is_valid_vector_argument<int>    : public std::true_type {};
-template <> struct is_valid_vector_argument<uint>   : public std::true_type {};
-template <> struct is_valid_vector_argument<short>  : public std::true_type {};
-template <> struct is_valid_vector_argument<ushort> : public std::true_type {};
 }  // namespace SSE
 
 namespace Traits
 {
 template <class T> struct
 is_simd_vector_internal<Vector<T, VectorAbi::Sse>>
-  : public SSE::is_valid_vector_argument<T> {};
+  : public is_valid_vector_argument<T> {};
 
 template<typename T> struct is_simd_mask_internal<Mask<T, VectorAbi::Sse>>
   : public std::true_type {};

--- a/traits/type_traits.h
+++ b/traits/type_traits.h
@@ -56,6 +56,16 @@ namespace Traits
 #include "has_addition_operator.h"
 #include "has_equality_operator.h"
 
+
+template<typename T> struct is_valid_vector_argument : public std::false_type {};
+
+template <> struct is_valid_vector_argument<double> : public std::true_type {};
+template <> struct is_valid_vector_argument<float>  : public std::true_type {};
+template <> struct is_valid_vector_argument<int>    : public std::true_type {};
+template <> struct is_valid_vector_argument<uint>   : public std::true_type {};
+template <> struct is_valid_vector_argument<short>  : public std::true_type {};
+template <> struct is_valid_vector_argument<ushort> : public std::true_type {};
+
 template<typename T> struct is_simd_mask_internal : public std::false_type {};
 template<typename T> struct is_simd_vector_internal : public std::false_type {};
 template<typename T> struct is_subscript_operation_internal : public std::false_type {};


### PR DESCRIPTION
commit 06f6324a11fbfd0d1d2e13ab9e6a019914c8a1b3
Author: Kay F. Jahnke <kfjahnke@gmail.com>
Date:   Thu Oct 5 14:19:52 2017 +0200

    as discussed on the ML, introducing is_valid_vector_argument
    I (kfj) proposed:
    .
    Consider this change to .../Vc/avx/types.h and .../vc/sse/types.h,
    towards the end, to have (given for .../Vc/avx/types.h):
    
    namepace Traits
    {
    // instead of the blanket statement:
    
    // template<typename T> struct
    // is_simd_vector_internal<Vector<T, VectorAbi::Avx>>
    //  : public std::true_type {};
    
    // partial specialization only for vectorizable types,
    // which is a bit like an 'enumeration'
    
    template<> struct
    is_simd_vector_internal<Vector<double, VectorAbi::Avx>>
     : public std::true_type {};
    
    to which mkretz answered:
    
    Ah yes. This can be generalized further to:
    
    template <class T> struct is_valid_vector_argument
      : public std::false_type {};
    ...
    
    And then:
    template <class T> struct
    is_simd_vector_internal<Vector<T, VectorAbi::Avx>>
      : public is_valid_vector_argument<T> {};
    
    I'd accept a pull request.
    
    So this commit introduces the changes to Avx ans Sse.

... and here's the pull request, to new feature branch vectorizable off 1.3, I hope I did it all right.

with regards

Kay F. Jahnke