### PR TITLE
Allow integers other than int as right-hand operand to << and >>

### DIFF
--- a/Vc/detail/simd.h
+++ b/Vc/detail/simd.h
@@ -120,8 +120,10 @@ public:
     friend V operator^ (const V &x, const V &y) { return simd_int_operators::make_derived(impl::bit_xor        (data(x), data(y))); }
     friend V operator<<(const V &x, const V &y) { return simd_int_operators::make_derived(impl::bit_shift_left (data(x), data(y))); }
     friend V operator>>(const V &x, const V &y) { return simd_int_operators::make_derived(impl::bit_shift_right(data(x), data(y))); }
-    friend V operator<<(const V &x, int y)      { return simd_int_operators::make_derived(impl::bit_shift_left (data(x), y)); }
-    friend V operator>>(const V &x, int y)      { return simd_int_operators::make_derived(impl::bit_shift_right(data(x), y)); }
+    template<class T>
+    friend V operator<<(const V &x, const T &y) { return simd_int_operators::make_derived(impl::bit_shift_left (data(x), y)); }
+    template<class T>
+    friend V operator>>(const V &x, const T &y) { return simd_int_operators::make_derived(impl::bit_shift_right(data(x), y)); }
 
     // unary operators (for integral T)
     V operator~() const


### PR DESCRIPTION
As discussed via email, here is the single change to Vc necessary to achieve [basic interop](https://github.com/johnmcfarlane/cnl/pull/147/files#diff-1644c4f6865f56044110089efe4a791c) between `vc::simd` and `cnl::fixed_point`. What that provides is a way to automate the work of applying fixed-point arithmetic to SIMD registers.

Notes:
* I picked *mkretz/concentrate* off of which to base this change because it appears to be much progressed and because *master* does not compile debug builds. That's no reason for me to switch to *master* if you'd prefer.
* This change may very likely break the interface or cause significant pessimization. I don't understand the library well enough to judge that easily. However, I got quite far building a GCC 6.x version of the library and hit problems with the change as presented here:
  * There is an ambiguous overload error because the new function templates cover calls where both inputs are of type, `V`. I've no idea why this code even works under GCC 7.x.
  * Removing the two overloads entirely is one way to fix the problem. However, that likely means that an integer is converted to a pack of integers before the shift operation is applied. I'm assuming that's a pessimization.
  * SFINAE is one way I considered making sure that the right call is made without ambiguity. That may be the best approach. If so, I would recommend the test `std::numeric_limits<T>::is_integer` and *not* `std::is_integral_v<T>`. Bear in mind that these overloads need to accept types which are not fundamental integers.
* Do not be alarmed by the specialization, [numeric_limits<Vc::simd<>>](https://github.com/johnmcfarlane/cnl/pull/147/files#diff-1644c4f6865f56044110089efe4a791cR9)! That is (arguably) a wart in the design as it currently stands. There needs to be a new type trait -- like `std::is_integral` -- which says "this is a good type for use with `fixed_point` and types like that".
* I think that your *mkretz/concentrate* branch is fairly close to supporting other compilers. Clang 6 -- and maybe even Clang 4 and GCC 6 -- should be achievable with relatively little effort. In particular, note that the `_v` type traits are not well supported under Clang.
* The CNL change is very limited. There's every chance that other changes are required to Vc and which affect standardization.
* I did not add tests. If there's anywhere you'd like to see a test, point me in that direction.