### PR TITLE
Use T/F instead of True/False in conditional template

### DIFF
--- a/common/simdarray.h
+++ b/common/simdarray.h
@@ -1547,8 +1547,8 @@ private:
     using LScalar = Traits::entry_type_of<L>;
     using RScalar = Traits::entry_type_of<R>;
 
-    template <bool B, typename True, typename False>
-    using conditional = typename std::conditional<B, True, False>::type;
+    template <bool B, typename T, typename F>
+    using conditional = typename std::conditional<B, T, F>::type;
 
 public:
     // In principle we want the exact same rules for SimdArray<T> ⨉ SimdArray<U> as the standard

--- a/godbolt.h
+++ b/godbolt.h
@@ -30802,8 +30802,8 @@ private:
     using LScalar = Traits::entry_type_of<L>;
     using RScalar = Traits::entry_type_of<R>;
 
-    template <bool B, typename True, typename False>
-    using conditional = typename std::conditional<B, True, False>::type;
+    template <bool B, typename T, typename F>
+    using conditional = typename std::conditional<B, T, F>::type;
 
 public:
     // In principle we want the exact same rules for SimdArray<T> ⨉ SimdArray<U> as the standard


### PR DESCRIPTION
In libraries where `True` and `False` are defined to be other values and uses `Vc` as an add-on, conflicts can arise.

```
/home/arif7/rootbuild/include/Vc/common/simdarray.h:1551:65: error: type/value mismatch at argument 2 in template parameter list for ‘template<bool <anonymous>, class, class> struct std::conditional’
     using conditional = typename std::conditional<B, True, False>::type;

```