### PR TITLE
Added `AVX2+FMA+BMI2` option in `vc_compile_for_all_implementations` …

### DIFF
--- a/doc/dox.h
+++ b/doc/dox.h
@@ -429,6 +429,7 @@ AVX. Here is the currently complete list of possible targets the macro will comp
 \li SSE+XOP+FMA4
 \li AVX
 \li AVX+XOP+FMA4
+\li AVX2+FMA+BMI2
 
 \section buildsystem_other Using Vc without CMake
 


### PR DESCRIPTION
…documentation

I hope this is correct. I was looking for AVX2 support and I fund this option and a few others not listed in current documentation in `CMakeLists.txt` file, but I don't know CMake syntax.