### PR TITLE
Faster Mask::firstOne()

### DIFF
--- a/Vc/avx/mask.h
+++ b/Vc/avx/mask.h
@@ -214,7 +214,7 @@ public:
     }
 
         Vc_INTRINSIC Vc_PURE int count() const { return Detail::popcnt16(toInt()); }
-        Vc_INTRINSIC Vc_PURE int firstOne() const { return _bit_scan_forward(toInt()); }
+        Vc_ALWAYS_INLINE_L Vc_PURE_L int firstOne() const Vc_ALWAYS_INLINE_R Vc_PURE_R;
 
         template <typename G> static Vc_INTRINSIC_L Mask generate(G &&gen) Vc_INTRINSIC_R;
         Vc_INTRINSIC_L Vc_PURE_L Mask shifted(int amount) const Vc_INTRINSIC_R Vc_PURE_R;

--- a/Vc/avx/mask.tcc
+++ b/Vc/avx/mask.tcc
@@ -109,6 +109,25 @@ template <typename T> Vc_INTRINSIC bool Mask<T, VectorAbi::Avx>::isMix() const {
     }
 }
 
+// firstOne {{{1
+template<typename T> Vc_ALWAYS_INLINE Vc_PURE int Mask<T, VectorAbi::Avx>::firstOne() const
+{
+    const int mask = toInt();
+#ifdef _MSC_VER
+    unsigned long bit;
+    _BitScanForward(&bit, mask);
+#else
+    int def = Size;
+    int bit;
+    __asm__(
+        "bsf %[mask], %[bit];"
+        "cmovz %[def], %[bit];"
+        :[bit] "=r" (bit)
+        :[mask] "r"(mask), [def] "r"(def));
+#endif
+    return bit;
+}
+
 // generate {{{1
 template <typename M, typename G>
 Vc_INTRINSIC M generate_impl(G &&gen, std::integral_constant<int, 4 + 32>)

--- a/Vc/sse/mask.tcc
+++ b/Vc/sse/mask.tcc
@@ -224,8 +224,13 @@ template<typename T> Vc_ALWAYS_INLINE Vc_PURE int Mask<T, VectorAbi::Sse>::first
     unsigned long bit;
     _BitScanForward(&bit, mask);
 #else
+    int def = Size;
     int bit;
-    __asm__("bsf %1,%0" : "=&r"(bit) : "r"(mask));
+    __asm__(
+        "bsf %[mask], %[bit];"
+        "cmovz %[def], %[bit];"
+        :[bit] "=r" (bit)
+        :[mask] "r"(mask), [def] "r"(def));
 #endif
     return bit;
 }


### PR DESCRIPTION
This change removes the undefined behaviour on firstOne method when used on an empty mask.

I did that for 2 reasons:
1) Undefined behaviour is not exactly a nice thing. And more important,
2) Is faster than check beforehand if the mask is empty.

This change made a 5% speed improvement on my tests [1] on average.  The code is a generic lower_bound using SIMD instructions and uses Vc.

I choose to return Mask::Size because will change the function return pattern just a little. Instead of return [0, Size), returns [0, Size]. One alternative is firstOne receive the default value for empty masks, I think the speedup should be the same.

[1] https://github.com/andrelrt/VcAlgo/blob/CodeMigration/include/VcAlgo/details/lower_bound.h