### PR TITLE
Missing 8-bit vector type aliases and asociated min/max calls

### DIFF
--- a/Vc/avx/detail.h
+++ b/Vc/avx/detail.h
@@ -244,49 +244,112 @@ Vc_INTRINSIC __m256i load(const int *mem, when_streaming,
 }
 
 template <typename V, typename DstT>
-Vc_INTRINSIC __m256i load(const short *mem, when_unaligned,
-                          enable_if<(std::is_same<DstT, short>::value &&
-                                     std::is_same<V, __m256i>::value)> = nullarg)
+Vc_INTRINSIC __m256i
+load(const short *mem, when_unaligned,
+     enable_if<(std::is_same<DstT, short>::value && std::is_same<V, __m256i>::value)> =
+         nullarg)
 {
     return _mm256_loadu_si256(reinterpret_cast<const __m256i *>(mem));
 }
 
 template <typename V, typename DstT>
-Vc_INTRINSIC __m256i load(const short *mem, when_aligned,
-                          enable_if<(std::is_same<DstT, short>::value &&
-                                     std::is_same<V, __m256i>::value)> = nullarg)
+Vc_INTRINSIC __m256i
+load(const short *mem, when_aligned,
+     enable_if<(std::is_same<DstT, short>::value && std::is_same<V, __m256i>::value)> =
+         nullarg)
 {
     return _mm256_load_si256(reinterpret_cast<const __m256i *>(mem));
 }
 
 template <typename V, typename DstT>
-Vc_INTRINSIC __m256i load(const short *mem, when_streaming,
-                          enable_if<(std::is_same<DstT, short>::value &&
-                                     std::is_same<V, __m256i>::value)> = nullarg)
+Vc_INTRINSIC __m256i
+load(const short *mem, when_streaming,
+     enable_if<(std::is_same<DstT, short>::value && std::is_same<V, __m256i>::value)> =
+         nullarg)
 {
     return AvxIntrinsics::stream_load<__m256i>(mem);
 }
 
 template <typename V, typename DstT>
-Vc_INTRINSIC __m256i load(const ushort *mem, when_unaligned,
-                          enable_if<(std::is_same<DstT, ushort>::value &&
-                                     std::is_same<V, __m256i>::value)> = nullarg)
+Vc_INTRINSIC __m256i
+load(const ushort *mem, when_unaligned,
+     enable_if<(std::is_same<DstT, ushort>::value && std::is_same<V, __m256i>::value)> =
+         nullarg)
 {
     return _mm256_loadu_si256(reinterpret_cast<const __m256i *>(mem));
 }
 
 template <typename V, typename DstT>
-Vc_INTRINSIC __m256i load(const ushort *mem, when_aligned,
-                          enable_if<(std::is_same<DstT, ushort>::value &&
-                                     std::is_same<V, __m256i>::value)> = nullarg)
+Vc_INTRINSIC __m256i
+load(const ushort *mem, when_aligned,
+     enable_if<(std::is_same<DstT, ushort>::value && std::is_same<V, __m256i>::value)> =
+         nullarg)
 {
     return _mm256_load_si256(reinterpret_cast<const __m256i *>(mem));
 }
 
 template <typename V, typename DstT>
-Vc_INTRINSIC __m256i load(const ushort *mem, when_streaming,
-                          enable_if<(std::is_same<DstT, ushort>::value &&
-                                     std::is_same<V, __m256i>::value)> = nullarg)
+Vc_INTRINSIC __m256i
+load(const ushort *mem, when_streaming,
+     enable_if<(std::is_same<DstT, ushort>::value && std::is_same<V, __m256i>::value)> =
+         nullarg)
+{
+    return AvxIntrinsics::stream_load<__m256i>(mem);
+}
+
+
+//chars
+
+template <typename V, typename DstT>
+Vc_INTRINSIC __m256i
+load(const char *mem, when_unaligned,
+     enable_if<(std::is_same<DstT, char>::value && std::is_same<V, __m256i>::value)> =
+         nullarg)
+{
+    return _mm256_loadu_si256(reinterpret_cast<const __m256i *>(mem));
+}
+
+template <typename V, typename DstT>
+Vc_INTRINSIC __m256i
+load(const char *mem, when_aligned,
+     enable_if<(std::is_same<DstT, char>::value && std::is_same<V, __m256i>::value)> =
+         nullarg)
+{
+    return _mm256_load_si256(reinterpret_cast<const __m256i *>(mem));
+}
+
+template <typename V, typename DstT>
+Vc_INTRINSIC __m256i
+load(const char *mem, when_streaming,
+     enable_if<(std::is_same<DstT, char>::value && std::is_same<V, __m256i>::value)> =
+         nullarg)
+{
+    return AvxIntrinsics::stream_load<__m256i>(mem);
+}
+
+template <typename V, typename DstT>
+Vc_INTRINSIC __m256i
+load(const uchar *mem, when_unaligned,
+     enable_if<(std::is_same<DstT, uchar>::value && std::is_same<V, __m256i>::value)> =
+         nullarg)
+{
+    return _mm256_loadu_si256(reinterpret_cast<const __m256i *>(mem));
+}
+
+template <typename V, typename DstT>
+Vc_INTRINSIC __m256i
+load(const uchar *mem, when_aligned,
+     enable_if<(std::is_same<DstT, uchar>::value && std::is_same<V, __m256i>::value)> =
+         nullarg)
+{
+    return _mm256_load_si256(reinterpret_cast<const __m256i *>(mem));
+}
+
+template <typename V, typename DstT>
+Vc_INTRINSIC __m256i
+load(const uchar *mem, when_streaming,
+     enable_if<(std::is_same<DstT, uchar>::value && std::is_same<V, __m256i>::value)> =
+         nullarg)
 {
     return AvxIntrinsics::stream_load<__m256i>(mem);
 }

--- a/Vc/avx/detail.h
+++ b/Vc/avx/detail.h
@@ -1319,6 +1319,13 @@ template <> Vc_INTRINSIC Vc_CONST int mask_to_int<16>(__m256i k)
 {
     return _pext_u32(movemask(k), 0x55555555u);
 }
+#else
+template <> Vc_INTRINSIC Vc_CONST int mask_to_int<16>(__m256i k)
+{
+    int upper = movemask(AVX::avx_cast<__m256>(k)) << 8;
+    int lower = movemask(AVX::avx_cast<__m256>(_mm256_slli_epi32(k,16)));
+    return upper | lower;
+}
 #endif
 template <> Vc_INTRINSIC Vc_CONST int mask_to_int<32>(__m256i k)
 {

--- a/Vc/avx/detail.h
+++ b/Vc/avx/detail.h
@@ -699,6 +699,8 @@ Vc_INTRINSIC __m256i add(__m256i a, __m256i b,    int) { return AVX::add_epi32(a
 Vc_INTRINSIC __m256i add(__m256i a, __m256i b,   uint) { return AVX::add_epi32(a, b); }
 Vc_INTRINSIC __m256i add(__m256i a, __m256i b,  short) { return AVX::add_epi16(a, b); }
 Vc_INTRINSIC __m256i add(__m256i a, __m256i b, ushort) { return AVX::add_epi16(a, b); }
+Vc_INTRINSIC __m256i add(__m256i a, __m256i b,   char) { return AVX::add_epi8(a, b); }
+Vc_INTRINSIC __m256i add(__m256i a, __m256i b,  uchar) { return AVX::add_epi8(a, b); }
 
 // sub{{{1
 Vc_INTRINSIC __m256  sub(__m256  a, __m256  b,  float) { return _mm256_sub_ps(a, b); }
@@ -707,6 +709,8 @@ Vc_INTRINSIC __m256i sub(__m256i a, __m256i b,    int) { return AVX::sub_epi32(a
 Vc_INTRINSIC __m256i sub(__m256i a, __m256i b,   uint) { return AVX::sub_epi32(a, b); }
 Vc_INTRINSIC __m256i sub(__m256i a, __m256i b,  short) { return AVX::sub_epi16(a, b); }
 Vc_INTRINSIC __m256i sub(__m256i a, __m256i b, ushort) { return AVX::sub_epi16(a, b); }
+Vc_INTRINSIC __m256i sub(__m256i a, __m256i b,   char) { return AVX::sub_epi8(a, b); }
+Vc_INTRINSIC __m256i sub(__m256i a, __m256i b,  uchar) { return AVX::sub_epi8(a, b); }
 
 // mul{{{1
 Vc_INTRINSIC __m256  mul(__m256  a, __m256  b,  float) { return _mm256_mul_ps(a, b); }
@@ -787,6 +791,8 @@ Vc_INTRINSIC __m256i cmpeq(__m256i a, __m256i b,    int) { return AvxIntrinsics:
 Vc_INTRINSIC __m256i cmpeq(__m256i a, __m256i b,   uint) { return AvxIntrinsics::cmpeq_epi32(a, b); }
 Vc_INTRINSIC __m256i cmpeq(__m256i a, __m256i b,  short) { return AvxIntrinsics::cmpeq_epi16(a, b); }
 Vc_INTRINSIC __m256i cmpeq(__m256i a, __m256i b, ushort) { return AvxIntrinsics::cmpeq_epi16(a, b); }
+Vc_INTRINSIC __m256i cmpeq(__m256i a, __m256i b,  schar) { return AvxIntrinsics::cmpeq_epi8(a, b); }
+Vc_INTRINSIC __m256i cmpeq(__m256i a, __m256i b,  uchar) { return AvxIntrinsics::cmpeq_epi8(a, b); }
 
 // cmpneq{{{1
 Vc_INTRINSIC __m256  cmpneq(__m256  a, __m256  b,  float) { return AvxIntrinsics::cmpneq_ps(a, b); }

--- a/Vc/avx/intrinsics.h
+++ b/Vc/avx/intrinsics.h
@@ -454,6 +454,9 @@ static Vc_INTRINSIC m256i cmplt_epi8(__m256i a, __m256i b) {
 static Vc_INTRINSIC m256i cmpgt_epu8(__m256i a, __m256i b) {
     return cmpgt_epi8(xor_si256(a, setmin_epi8()), xor_si256(b, setmin_epi8()));
 }
+static Vc_INTRINSIC m256i cmplt_epu8(__m256i a, __m256i b) {
+    return cmpgt_epu8(b, a);
+}
 #if defined(Vc_IMPL_XOP)
     Vc_AVX_TO_SSE_2_NEW(comlt_epu32)
     Vc_AVX_TO_SSE_2_NEW(comgt_epu32)

--- a/Vc/avx/intrinsics.h
+++ b/Vc/avx/intrinsics.h
@@ -355,11 +355,14 @@ namespace AvxIntrinsics
     Vc_AVX_TO_SSE_2_NEW(cmpgt_epi64)
     Vc_AVX_TO_SSE_2_NEW(unpackhi_epi16)
     Vc_AVX_TO_SSE_2_NEW(unpacklo_epi16)
+    Vc_AVX_TO_SSE_2_NEW(add_epi8)
     Vc_AVX_TO_SSE_2_NEW(add_epi16)
     Vc_AVX_TO_SSE_2_NEW(add_epi32)
     Vc_AVX_TO_SSE_2_NEW(add_epi64)
+    Vc_AVX_TO_SSE_2_NEW(sub_epi8)
     Vc_AVX_TO_SSE_2_NEW(sub_epi16)
     Vc_AVX_TO_SSE_2_NEW(sub_epi32)
+    Vc_AVX_TO_SSE_2_NEW(sub_epi64)
     Vc_AVX_TO_SSE_2_NEW(mullo_epi16)
     Vc_AVX_TO_SSE_2_NEW(sign_epi16)
     Vc_AVX_TO_SSE_2_NEW(sign_epi32)
@@ -518,8 +521,9 @@ static Vc_INTRINSIC void _mm256_maskstore(unsigned int *mem, const __m256i mask,
 }
 static Vc_INTRINSIC void _mm256_maskstore(short *mem, const __m256i mask, const __m256i v) {
     using namespace AVX;
-    _mm_maskmoveu_si128(extract128<0>(v), extract128<0>(mask), reinterpret_cast<char *>(&mem[0]));
-    _mm_maskmoveu_si128(extract128<1>(v), extract128<1>(mask), reinterpret_cast<char *>(&mem[8]));
+    __m256i tmp = _mm256_loadu_si256(reinterpret_cast<__m256i *>(mem));
+    tmp = _mm256_blendv_epi8(tmp, v, mask);
+    _mm256_storeu_si256(reinterpret_cast<__m256i *>(mem), tmp);
 }
 static Vc_INTRINSIC void _mm256_maskstore(unsigned short *mem, const __m256i mask, const __m256i v) {
     _mm256_maskstore(reinterpret_cast<short *>(mem), mask, v);

--- a/Vc/avx/intrinsics.h
+++ b/Vc/avx/intrinsics.h
@@ -514,6 +514,15 @@ static Vc_INTRINSIC void _mm256_maskstore(unsigned short *mem, const __m256i mas
     _mm256_maskstore(reinterpret_cast<short *>(mem), mask, v);
 }
 
+static Vc_INTRINSIC void _mm256_maskstore(char *mem, const __m256i mask, const __m256i v) {
+    _mm256_maskstore(reinterpret_cast<short *>(mem), mask, v);
+}
+
+static Vc_INTRINSIC void _mm256_maskstore(unsigned char *mem, const __m256i mask, const __m256i v) {
+    _mm256_maskstore(reinterpret_cast<short *>(mem), mask, v);
+}
+
+
 #undef Vc_AVX_TO_SSE_1
 #undef Vc_AVX_TO_SSE_1_128
 #undef Vc_AVX_TO_SSE_2_NEW

--- a/Vc/avx/math.h
+++ b/Vc/avx/math.h
@@ -40,10 +40,14 @@ Vc_ALWAYS_INLINE AVX2::int_v    min(const AVX2::int_v    &x, const AVX2::int_v  
 Vc_ALWAYS_INLINE AVX2::uint_v   min(const AVX2::uint_v   &x, const AVX2::uint_v   &y) { return _mm256_min_epu32(x.data(), y.data()); }
 Vc_ALWAYS_INLINE AVX2::short_v  min(const AVX2::short_v  &x, const AVX2::short_v  &y) { return _mm256_min_epi16(x.data(), y.data()); }
 Vc_ALWAYS_INLINE AVX2::ushort_v min(const AVX2::ushort_v &x, const AVX2::ushort_v &y) { return _mm256_min_epu16(x.data(), y.data()); }
+Vc_ALWAYS_INLINE AVX2::schar_v  min(const AVX2::schar_v  &x, const AVX2::schar_v  &y) { return _mm256_min_epi8(x.data(), y.data()); }
+Vc_ALWAYS_INLINE AVX2::uchar_v  min(const AVX2::uchar_v  &x, const AVX2::uchar_v  &y) { return _mm256_min_epu8(x.data(), y.data()); }
 Vc_ALWAYS_INLINE AVX2::int_v    max(const AVX2::int_v    &x, const AVX2::int_v    &y) { return _mm256_max_epi32(x.data(), y.data()); }
 Vc_ALWAYS_INLINE AVX2::uint_v   max(const AVX2::uint_v   &x, const AVX2::uint_v   &y) { return _mm256_max_epu32(x.data(), y.data()); }
 Vc_ALWAYS_INLINE AVX2::short_v  max(const AVX2::short_v  &x, const AVX2::short_v  &y) { return _mm256_max_epi16(x.data(), y.data()); }
 Vc_ALWAYS_INLINE AVX2::ushort_v max(const AVX2::ushort_v &x, const AVX2::ushort_v &y) { return _mm256_max_epu16(x.data(), y.data()); }
+Vc_ALWAYS_INLINE AVX2::schar_v  max(const AVX2::schar_v  &x, const AVX2::schar_v  &y) { return _mm256_max_epi8(x.data(), y.data()); }
+Vc_ALWAYS_INLINE AVX2::uchar_v  max(const AVX2::uchar_v  &x, const AVX2::uchar_v  &y) { return _mm256_max_epu8(x.data(), y.data()); }
 #endif
 Vc_ALWAYS_INLINE AVX2::float_v  min(const AVX2::float_v  &x, const AVX2::float_v  &y) { return _mm256_min_ps(x.data(), y.data()); }
 Vc_ALWAYS_INLINE AVX2::double_v min(const AVX2::double_v &x, const AVX2::double_v &y) { return _mm256_min_pd(x.data(), y.data()); }

--- a/Vc/avx/simd_cast_caller.tcc
+++ b/Vc/avx/simd_cast_caller.tcc
@@ -44,7 +44,7 @@ template <typename T>
 template <typename U>
 Vc_INTRINSIC Mask<T, VectorAbi::Avx>::Mask(U &&rhs,
                                  Common::enable_if_mask_converts_explicitly<T, U>)
-    : Mask(simd_cast<Mask>(std::forward<U>(rhs)))
+    : d(simd_cast<Mask>(std::forward<U>(rhs)))
 {
 }
 #endif  // Vc_IS_VERSION_1

--- a/Vc/avx/types.h
+++ b/Vc/avx/types.h
@@ -59,6 +59,8 @@ typedef Vector<int>               int_v;
 typedef Vector<unsigned int>     uint_v;
 typedef Vector<short>           short_v;
 typedef Vector<unsigned short> ushort_v;
+typedef Vector<char>            schar_v;
+typedef Vector<unsigned char>   uchar_v;
 
 template <typename T> using Mask = Vc::Mask<T, VectorAbi::Avx1Abi<T>>;
 typedef Mask<double>         double_m;
@@ -67,6 +69,8 @@ typedef Mask<int>               int_m;
 typedef Mask<unsigned int>     uint_m;
 typedef Mask<short>           short_m;
 typedef Mask<unsigned short> ushort_m;
+typedef Mask<char>            schar_m;
+typedef Mask<unsigned char>   uchar_m;
 
 template <typename T> struct Const;
 
@@ -85,6 +89,8 @@ using    int_v = Vector<   int>;
 using   uint_v = Vector<  uint>;
 using  short_v = Vector< short>;
 using ushort_v = Vector<ushort>;
+using  schar_v = Vector< char>;
+using  uchar_v = Vector<uchar>;
 
 template <typename T> using Mask = Vc::Mask<T, VectorAbi::Avx>;
 using double_m = Mask<double>;

--- a/Vc/avx/vector.tcc
+++ b/Vc/avx/vector.tcc
@@ -56,26 +56,38 @@ Vc_INTRINSIC AVX2::   int_m operator==(AVX2::   int_v a, AVX2::   int_v b) { ret
 Vc_INTRINSIC AVX2::  uint_m operator==(AVX2::  uint_v a, AVX2::  uint_v b) { return AVX::cmpeq_epi32(a.data(), b.data()); }
 Vc_INTRINSIC AVX2:: short_m operator==(AVX2:: short_v a, AVX2:: short_v b) { return AVX::cmpeq_epi16(a.data(), b.data()); }
 Vc_INTRINSIC AVX2::ushort_m operator==(AVX2::ushort_v a, AVX2::ushort_v b) { return AVX::cmpeq_epi16(a.data(), b.data()); }
+Vc_INTRINSIC AVX2:: schar_m operator==(AVX2::schar_v  a, AVX2::schar_v  b) { return AVX::cmpeq_epi8(a.data(), b.data()); }
+Vc_INTRINSIC AVX2:: uchar_m operator==(AVX2::uchar_v  a, AVX2::uchar_v  b) { return AVX::cmpeq_epi8(a.data(), b.data()); }
 Vc_INTRINSIC AVX2::   int_m operator!=(AVX2::   int_v a, AVX2::   int_v b) { return not_(AVX::cmpeq_epi32(a.data(), b.data())); }
 Vc_INTRINSIC AVX2::  uint_m operator!=(AVX2::  uint_v a, AVX2::  uint_v b) { return not_(AVX::cmpeq_epi32(a.data(), b.data())); }
 Vc_INTRINSIC AVX2:: short_m operator!=(AVX2:: short_v a, AVX2:: short_v b) { return not_(AVX::cmpeq_epi16(a.data(), b.data())); }
 Vc_INTRINSIC AVX2::ushort_m operator!=(AVX2::ushort_v a, AVX2::ushort_v b) { return not_(AVX::cmpeq_epi16(a.data(), b.data())); }
+Vc_INTRINSIC AVX2:: schar_m operator!=(AVX2::schar_v  a, AVX2::schar_v  b) { return not_(AVX::cmpeq_epi8(a.data(), b.data())); }
+Vc_INTRINSIC AVX2:: uchar_m operator!=(AVX2::uchar_v  a, AVX2::uchar_v  b) { return not_(AVX::cmpeq_epi8(a.data(), b.data())); }
 Vc_INTRINSIC AVX2::   int_m operator>=(AVX2::   int_v a, AVX2::   int_v b) { return not_(AVX::cmplt_epi32(a.data(), b.data())); }
 Vc_INTRINSIC AVX2::  uint_m operator>=(AVX2::  uint_v a, AVX2::  uint_v b) { return not_(AVX::cmplt_epu32(a.data(), b.data())); }
 Vc_INTRINSIC AVX2:: short_m operator>=(AVX2:: short_v a, AVX2:: short_v b) { return not_(AVX::cmplt_epi16(a.data(), b.data())); }
 Vc_INTRINSIC AVX2::ushort_m operator>=(AVX2::ushort_v a, AVX2::ushort_v b) { return not_(AVX::cmplt_epu16(a.data(), b.data())); }
+Vc_INTRINSIC AVX2:: schar_m operator>=(AVX2::schar_v  a, AVX2::schar_v  b) { return not_(AVX::cmplt_epi8(a.data(), b.data())); }
+Vc_INTRINSIC AVX2:: uchar_m operator>=(AVX2::uchar_v  a, AVX2::uchar_v  b) { return not_(AVX::cmplt_epu8(a.data(), b.data())); }
 Vc_INTRINSIC AVX2::   int_m operator<=(AVX2::   int_v a, AVX2::   int_v b) { return not_(AVX::cmpgt_epi32(a.data(), b.data())); }
 Vc_INTRINSIC AVX2::  uint_m operator<=(AVX2::  uint_v a, AVX2::  uint_v b) { return not_(AVX::cmpgt_epu32(a.data(), b.data())); }
 Vc_INTRINSIC AVX2:: short_m operator<=(AVX2:: short_v a, AVX2:: short_v b) { return not_(AVX::cmpgt_epi16(a.data(), b.data())); }
 Vc_INTRINSIC AVX2::ushort_m operator<=(AVX2::ushort_v a, AVX2::ushort_v b) { return not_(AVX::cmpgt_epu16(a.data(), b.data())); }
+Vc_INTRINSIC AVX2:: schar_m operator<=(AVX2::schar_v  a, AVX2::schar_v  b) { return not_(AVX::cmpgt_epi8(a.data(), b.data())); }
+Vc_INTRINSIC AVX2:: uchar_m operator<=(AVX2::uchar_v  a, AVX2::uchar_v  b) { return not_(AVX::cmpgt_epu8(a.data(), b.data())); }
 Vc_INTRINSIC AVX2::   int_m operator> (AVX2::   int_v a, AVX2::   int_v b) { return AVX::cmpgt_epi32(a.data(), b.data()); }
 Vc_INTRINSIC AVX2::  uint_m operator> (AVX2::  uint_v a, AVX2::  uint_v b) { return AVX::cmpgt_epu32(a.data(), b.data()); }
 Vc_INTRINSIC AVX2:: short_m operator> (AVX2:: short_v a, AVX2:: short_v b) { return AVX::cmpgt_epi16(a.data(), b.data()); }
 Vc_INTRINSIC AVX2::ushort_m operator> (AVX2::ushort_v a, AVX2::ushort_v b) { return AVX::cmpgt_epu16(a.data(), b.data()); }
+Vc_INTRINSIC AVX2:: schar_m operator> (AVX2::schar_v  a, AVX2::schar_v  b) { return AVX::cmpgt_epi8(a.data(), b.data()); }
+Vc_INTRINSIC AVX2:: uchar_m operator> (AVX2::uchar_v  a, AVX2::uchar_v  b) { return AVX::cmpgt_epu8(a.data(), b.data()); }
 Vc_INTRINSIC AVX2::   int_m operator< (AVX2::   int_v a, AVX2::   int_v b) { return AVX::cmplt_epi32(a.data(), b.data()); }
 Vc_INTRINSIC AVX2::  uint_m operator< (AVX2::  uint_v a, AVX2::  uint_v b) { return AVX::cmplt_epu32(a.data(), b.data()); }
 Vc_INTRINSIC AVX2:: short_m operator< (AVX2:: short_v a, AVX2:: short_v b) { return AVX::cmplt_epi16(a.data(), b.data()); }
 Vc_INTRINSIC AVX2::ushort_m operator< (AVX2::ushort_v a, AVX2::ushort_v b) { return AVX::cmplt_epu16(a.data(), b.data()); }
+Vc_INTRINSIC AVX2:: schar_m operator< (AVX2::schar_v  a, AVX2::schar_v  b) { return AVX::cmplt_epi8(a.data(), b.data()); }
+Vc_INTRINSIC AVX2:: uchar_m operator< (AVX2::uchar_v  a, AVX2::uchar_v  b) { return AVX::cmplt_epu8(a.data(), b.data()); }
 #endif  // Vc_IMPL_AVX2
 
 // bitwise operators {{{1

--- a/Vc/sse/const_data.h
+++ b/Vc/sse/const_data.h
@@ -47,6 +47,7 @@ struct c_general
     alignas(16) static const unsigned int highMaskFloat[4];
     alignas(16) static const short minShort[8];
 
+    alignas(16) static const unsigned char one8[16];
     alignas(16) static const unsigned short one16[8];
     alignas(16) static const unsigned int one32[4];
     alignas(16) static const float oneFloat[4];

--- a/Vc/sse/detail.h
+++ b/Vc/sse/detail.h
@@ -163,6 +163,24 @@ Vc_INTRINSIC __m128i load(const ushort *mem, F f,
 {
     return load16(mem, f);
 }
+
+template <typename V, typename DstT, typename F>
+Vc_INTRINSIC __m128i
+load(const char *mem, F f,
+     enable_if<(std::is_same<DstT, char>::value && std::is_same<V, __m128i>::value)> =
+         nullarg)
+{
+    return load16(mem, f);
+}
+
+template <typename V, typename DstT, typename F>
+Vc_INTRINSIC __m128i
+load(const uchar *mem, F f,
+     enable_if<(std::is_same<DstT, uchar>::value && std::is_same<V, __m128i>::value)> =
+         nullarg)
+{
+    return load16(mem, f);
+}
 #endif  // Vc_MSVC
 
 // generic load{{{2

--- a/Vc/sse/intrinsics.h
+++ b/Vc/sse/intrinsics.h
@@ -77,9 +77,11 @@ namespace SseIntrinsics
     static Vc_INTRINSIC Vc_CONST __m128i _mm_setallone_si128() { return _mm_load_si128(reinterpret_cast<const __m128i *>(Common::AllBitsSet)); }
     static Vc_INTRINSIC Vc_CONST __m128d _mm_setallone_pd() { return _mm_load_pd(reinterpret_cast<const double *>(Common::AllBitsSet)); }
     static Vc_INTRINSIC Vc_CONST __m128  _mm_setallone_ps() { return _mm_load_ps(reinterpret_cast<const float *>(Common::AllBitsSet)); }
-
-    static Vc_INTRINSIC __m128i Vc_CONST _mm_setone_epi16()  { return _mm_load_si128(reinterpret_cast<const __m128i *>(c_general::one16)); }
-    static Vc_INTRINSIC __m128i Vc_CONST _mm_setone_epu16()  { return _mm_setone_epi16(); }
+	
+    static Vc_INTRINSIC __m128i Vc_CONST _mm_setone_epi8()  { return _mm_load_si128(reinterpret_cast<const __m128i *>(c_general::one8)); }
+    static Vc_INTRINSIC __m128i Vc_CONST _mm_setone_epu8()  { return _mm_setone_epi8(); }
+    static Vc_INTRINSIC __m128i Vc_CONST _mm_setone_epi16() { return _mm_load_si128(reinterpret_cast<const __m128i *>(c_general::one16)); }
+    static Vc_INTRINSIC __m128i Vc_CONST _mm_setone_epu16() { return _mm_setone_epi16(); }
     static Vc_INTRINSIC __m128i Vc_CONST _mm_setone_epi32()  { return _mm_load_si128(reinterpret_cast<const __m128i *>(c_general::one32)); }
     static Vc_INTRINSIC __m128i Vc_CONST _mm_setone_epu32()  { return _mm_setone_epi32(); }
 
@@ -541,6 +543,9 @@ namespace SseIntrinsics
     }
     Vc_INTRINSIC Vc_CONST __m128i min_epi8 (__m128i a, __m128i b) {
         return blendv_epi8(a, b, _mm_cmpgt_epi8 (a, b));
+    }
+    Vc_INTRINSIC Vc_CONST __m128i min_epu8 (__m128i a, __m128i b) {
+        return blendv_epi8(a, b, cmpgt_epu8 (a, b));
     }
     Vc_INTRINSIC Vc_CONST __m128i min_epi32(__m128i a, __m128i b) {
         return blendv_epi8(a, b, _mm_cmpgt_epi32(a, b));

--- a/Vc/sse/math.h
+++ b/Vc/sse/math.h
@@ -33,6 +33,43 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 namespace Vc_VERSIONED_NAMESPACE
 {
+
+static Vc_ALWAYS_INLINE Vc_PURE SSE::int_v    min(const SSE::int_v    &x, const SSE::int_v    &y) { return SSE::min_epi32(x.data(), y.data()); }
+static Vc_ALWAYS_INLINE Vc_PURE SSE::uint_v   min(const SSE::uint_v   &x, const SSE::uint_v   &y) { return SSE::min_epu32(x.data(), y.data()); }
+static Vc_ALWAYS_INLINE Vc_PURE SSE::short_v  min(const SSE::short_v  &x, const SSE::short_v  &y) { return _mm_min_epi16(x.data(), y.data()); }
+static Vc_ALWAYS_INLINE Vc_PURE SSE::ushort_v min(const SSE::ushort_v &x, const SSE::ushort_v &y) { return SSE::min_epu16(x.data(), y.data()); }
+static Vc_ALWAYS_INLINE Vc_PURE SSE::schar_v  min(const SSE::schar_v  &x, const SSE::schar_v  &y) { return SSE::min_epi8(x.data(), y.data()); }
+static Vc_ALWAYS_INLINE Vc_PURE SSE::uchar_v  min(const SSE::uchar_v  &x, const SSE::uchar_v  &y) { return _mm_min_epu8(x.data(), y.data()); }
+static Vc_ALWAYS_INLINE Vc_PURE SSE::float_v  min(const SSE::float_v  &x, const SSE::float_v  &y) { return _mm_min_ps(x.data(), y.data()); }
+static Vc_ALWAYS_INLINE Vc_PURE SSE::double_v min(const SSE::double_v &x, const SSE::double_v &y) { return _mm_min_pd(x.data(), y.data()); }
+static Vc_ALWAYS_INLINE Vc_PURE SSE::int_v    max(const SSE::int_v    &x, const SSE::int_v    &y) { return SSE::max_epi32(x.data(), y.data()); }
+static Vc_ALWAYS_INLINE Vc_PURE SSE::uint_v   max(const SSE::uint_v   &x, const SSE::uint_v   &y) { return SSE::max_epu32(x.data(), y.data()); }
+static Vc_ALWAYS_INLINE Vc_PURE SSE::short_v  max(const SSE::short_v  &x, const SSE::short_v  &y) { return _mm_max_epi16(x.data(), y.data()); }
+static Vc_ALWAYS_INLINE Vc_PURE SSE::ushort_v max(const SSE::ushort_v &x, const SSE::ushort_v &y) { return SSE::max_epu16(x.data(), y.data()); }
+static Vc_ALWAYS_INLINE Vc_PURE SSE::schar_v  max(const SSE::schar_v  &x, const SSE::schar_v  &y) { return SSE::max_epi8(x.data(), y.data()); }
+static Vc_ALWAYS_INLINE Vc_PURE SSE::uchar_v  max(const SSE::uchar_v  &x, const SSE::uchar_v  &y) { return _mm_max_epu8(x.data(), y.data()); }
+static Vc_ALWAYS_INLINE Vc_PURE SSE::float_v  max(const SSE::float_v  &x, const SSE::float_v  &y) { return _mm_max_ps(x.data(), y.data()); }
+static Vc_ALWAYS_INLINE Vc_PURE SSE::double_v max(const SSE::double_v &x, const SSE::double_v &y) { return _mm_max_pd(x.data(), y.data()); }
+
+template <typename T,
+          typename = enable_if<std::is_same<T, double>::value || std::is_same<T, float>::value ||
+                               std::is_same<T, short>::value ||
+                               std::is_same<T, int>::value>>
+Vc_ALWAYS_INLINE Vc_PURE Vector<T, VectorAbi::Sse> abs(Vector<T, VectorAbi::Sse> x)
+{
+    return SSE::VectorHelper<T>::abs(x.data());
+}
+
+  template<typename T> Vc_ALWAYS_INLINE Vc_PURE Vector<T, VectorAbi::Sse> sqrt (const Vector<T, VectorAbi::Sse> &x) { return SSE::VectorHelper<T>::sqrt(x.data()); }
+  template<typename T> Vc_ALWAYS_INLINE Vc_PURE Vector<T, VectorAbi::Sse> rsqrt(const Vector<T, VectorAbi::Sse> &x) { return SSE::VectorHelper<T>::rsqrt(x.data()); }
+  template<typename T> Vc_ALWAYS_INLINE Vc_PURE Vector<T, VectorAbi::Sse> reciprocal(const Vector<T, VectorAbi::Sse> &x) { return SSE::VectorHelper<T>::reciprocal(x.data()); }
+  template<typename T> Vc_ALWAYS_INLINE Vc_PURE Vector<T, VectorAbi::Sse> round(const Vector<T, VectorAbi::Sse> &x) { return SSE::VectorHelper<T>::round(x.data()); }
+
+  template<typename T> Vc_ALWAYS_INLINE Vc_PURE typename Vector<T, VectorAbi::Sse>::Mask isfinite(const Vector<T, VectorAbi::Sse> &x) { return SSE::VectorHelper<T>::isFinite(x.data()); }
+  template<typename T> Vc_ALWAYS_INLINE Vc_PURE typename Vector<T, VectorAbi::Sse>::Mask isinf(const Vector<T, VectorAbi::Sse> &x) { return SSE::VectorHelper<T>::isInfinite(x.data()); }
+  template<typename T> Vc_ALWAYS_INLINE Vc_PURE typename Vector<T, VectorAbi::Sse>::Mask isnan(const Vector<T, VectorAbi::Sse> &x) { return SSE::VectorHelper<T>::isNaN(x.data()); }
+
+
 // copysign {{{1
 Vc_INTRINSIC Vc_CONST SSE::float_v copysign(SSE::float_v mag, SSE::float_v sign)
 {

--- a/Vc/sse/types.h
+++ b/Vc/sse/types.h
@@ -50,6 +50,8 @@ typedef Vector<int>               int_v;
 typedef Vector<unsigned int>     uint_v;
 typedef Vector<short>           short_v;
 typedef Vector<unsigned short> ushort_v;
+typedef Vector<char>            schar_v;
+typedef Vector<unsigned char>   uchar_v;
 
 template <typename T> using Mask = Vc::Mask<T, VectorAbi::Sse>;
 typedef Mask<double>         double_m;
@@ -58,6 +60,9 @@ typedef Mask<int>               int_m;
 typedef Mask<unsigned int>     uint_m;
 typedef Mask<short>           short_m;
 typedef Mask<unsigned short> ushort_m;
+typedef Mask<char>            schar_m;
+typedef Mask<unsigned char>   uchar_m;
+
 
 template <typename T> struct Const;
 

--- a/Vc/sse/vector.h
+++ b/Vc/sse/vector.h
@@ -425,41 +425,6 @@ template <typename T> class Vector<T, VectorAbi::Sse>
 template <typename T> constexpr size_t Vector<T, VectorAbi::Sse>::Size;
 template <typename T> constexpr size_t Vector<T, VectorAbi::Sse>::MemoryAlignment;
 
-static Vc_ALWAYS_INLINE Vc_PURE SSE::int_v    min(const SSE::int_v    &x, const SSE::int_v    &y) { return SSE::min_epi32(x.data(), y.data()); }
-static Vc_ALWAYS_INLINE Vc_PURE SSE::uint_v   min(const SSE::uint_v   &x, const SSE::uint_v   &y) { return SSE::min_epu32(x.data(), y.data()); }
-static Vc_ALWAYS_INLINE Vc_PURE SSE::short_v  min(const SSE::short_v  &x, const SSE::short_v  &y) { return _mm_min_epi16(x.data(), y.data()); }
-static Vc_ALWAYS_INLINE Vc_PURE SSE::ushort_v min(const SSE::ushort_v &x, const SSE::ushort_v &y) { return SSE::min_epu16(x.data(), y.data()); }
-static Vc_ALWAYS_INLINE Vc_PURE SSE::schar_v  min(const SSE::schar_v  &x, const SSE::schar_v  &y) { return SSE::min_epi8(x.data(), y.data()); }
-static Vc_ALWAYS_INLINE Vc_PURE SSE::uchar_v  min(const SSE::uchar_v  &x, const SSE::uchar_v  &y) { return _mm_min_epu8(x.data(), y.data()); }
-static Vc_ALWAYS_INLINE Vc_PURE SSE::float_v  min(const SSE::float_v  &x, const SSE::float_v  &y) { return _mm_min_ps(x.data(), y.data()); }
-static Vc_ALWAYS_INLINE Vc_PURE SSE::double_v min(const SSE::double_v &x, const SSE::double_v &y) { return _mm_min_pd(x.data(), y.data()); }
-static Vc_ALWAYS_INLINE Vc_PURE SSE::int_v    max(const SSE::int_v    &x, const SSE::int_v    &y) { return SSE::max_epi32(x.data(), y.data()); }
-static Vc_ALWAYS_INLINE Vc_PURE SSE::uint_v   max(const SSE::uint_v   &x, const SSE::uint_v   &y) { return SSE::max_epu32(x.data(), y.data()); }
-static Vc_ALWAYS_INLINE Vc_PURE SSE::short_v  max(const SSE::short_v  &x, const SSE::short_v  &y) { return _mm_max_epi16(x.data(), y.data()); }
-static Vc_ALWAYS_INLINE Vc_PURE SSE::ushort_v max(const SSE::ushort_v &x, const SSE::ushort_v &y) { return SSE::max_epu16(x.data(), y.data()); }
-static Vc_ALWAYS_INLINE Vc_PURE SSE::schar_v  max(const SSE::schar_v  &x, const SSE::schar_v  &y) { return SSE::max_epi8(x.data(), y.data()); }
-static Vc_ALWAYS_INLINE Vc_PURE SSE::uchar_v  max(const SSE::uchar_v  &x, const SSE::uchar_v  &y) { return _mm_max_epu8(x.data(), y.data()); }
-static Vc_ALWAYS_INLINE Vc_PURE SSE::float_v  max(const SSE::float_v  &x, const SSE::float_v  &y) { return _mm_max_ps(x.data(), y.data()); }
-static Vc_ALWAYS_INLINE Vc_PURE SSE::double_v max(const SSE::double_v &x, const SSE::double_v &y) { return _mm_max_pd(x.data(), y.data()); }
-
-template <typename T,
-          typename = enable_if<std::is_same<T, double>::value || std::is_same<T, float>::value ||
-                               std::is_same<T, short>::value ||
-                               std::is_same<T, int>::value>>
-Vc_ALWAYS_INLINE Vc_PURE Vector<T, VectorAbi::Sse> abs(Vector<T, VectorAbi::Sse> x)
-{
-    return SSE::VectorHelper<T>::abs(x.data());
-}
-
-  template<typename T> Vc_ALWAYS_INLINE Vc_PURE Vector<T, VectorAbi::Sse> sqrt (const Vector<T, VectorAbi::Sse> &x) { return SSE::VectorHelper<T>::sqrt(x.data()); }
-  template<typename T> Vc_ALWAYS_INLINE Vc_PURE Vector<T, VectorAbi::Sse> rsqrt(const Vector<T, VectorAbi::Sse> &x) { return SSE::VectorHelper<T>::rsqrt(x.data()); }
-  template<typename T> Vc_ALWAYS_INLINE Vc_PURE Vector<T, VectorAbi::Sse> reciprocal(const Vector<T, VectorAbi::Sse> &x) { return SSE::VectorHelper<T>::reciprocal(x.data()); }
-  template<typename T> Vc_ALWAYS_INLINE Vc_PURE Vector<T, VectorAbi::Sse> round(const Vector<T, VectorAbi::Sse> &x) { return SSE::VectorHelper<T>::round(x.data()); }
-
-  template<typename T> Vc_ALWAYS_INLINE Vc_PURE typename Vector<T, VectorAbi::Sse>::Mask isfinite(const Vector<T, VectorAbi::Sse> &x) { return SSE::VectorHelper<T>::isFinite(x.data()); }
-  template<typename T> Vc_ALWAYS_INLINE Vc_PURE typename Vector<T, VectorAbi::Sse>::Mask isinf(const Vector<T, VectorAbi::Sse> &x) { return SSE::VectorHelper<T>::isInfinite(x.data()); }
-  template<typename T> Vc_ALWAYS_INLINE Vc_PURE typename Vector<T, VectorAbi::Sse>::Mask isnan(const Vector<T, VectorAbi::Sse> &x) { return SSE::VectorHelper<T>::isNaN(x.data()); }
-
 #define Vc_CONDITIONAL_ASSIGN(name_, op_)                                                \
     template <Operator O, typename T, typename M, typename U>                            \
     Vc_INTRINSIC enable_if<O == Operator::name_, void> conditional_assign(               \

--- a/Vc/sse/vector.h
+++ b/Vc/sse/vector.h
@@ -429,12 +429,16 @@ static Vc_ALWAYS_INLINE Vc_PURE SSE::int_v    min(const SSE::int_v    &x, const 
 static Vc_ALWAYS_INLINE Vc_PURE SSE::uint_v   min(const SSE::uint_v   &x, const SSE::uint_v   &y) { return SSE::min_epu32(x.data(), y.data()); }
 static Vc_ALWAYS_INLINE Vc_PURE SSE::short_v  min(const SSE::short_v  &x, const SSE::short_v  &y) { return _mm_min_epi16(x.data(), y.data()); }
 static Vc_ALWAYS_INLINE Vc_PURE SSE::ushort_v min(const SSE::ushort_v &x, const SSE::ushort_v &y) { return SSE::min_epu16(x.data(), y.data()); }
+static Vc_ALWAYS_INLINE Vc_PURE SSE::schar_v  min(const SSE::schar_v  &x, const SSE::schar_v  &y) { return SSE::min_epi8(x.data(), y.data()); }
+static Vc_ALWAYS_INLINE Vc_PURE SSE::uchar_v  min(const SSE::uchar_v  &x, const SSE::uchar_v  &y) { return _mm_min_epu8(x.data(), y.data()); }
 static Vc_ALWAYS_INLINE Vc_PURE SSE::float_v  min(const SSE::float_v  &x, const SSE::float_v  &y) { return _mm_min_ps(x.data(), y.data()); }
 static Vc_ALWAYS_INLINE Vc_PURE SSE::double_v min(const SSE::double_v &x, const SSE::double_v &y) { return _mm_min_pd(x.data(), y.data()); }
 static Vc_ALWAYS_INLINE Vc_PURE SSE::int_v    max(const SSE::int_v    &x, const SSE::int_v    &y) { return SSE::max_epi32(x.data(), y.data()); }
 static Vc_ALWAYS_INLINE Vc_PURE SSE::uint_v   max(const SSE::uint_v   &x, const SSE::uint_v   &y) { return SSE::max_epu32(x.data(), y.data()); }
 static Vc_ALWAYS_INLINE Vc_PURE SSE::short_v  max(const SSE::short_v  &x, const SSE::short_v  &y) { return _mm_max_epi16(x.data(), y.data()); }
 static Vc_ALWAYS_INLINE Vc_PURE SSE::ushort_v max(const SSE::ushort_v &x, const SSE::ushort_v &y) { return SSE::max_epu16(x.data(), y.data()); }
+static Vc_ALWAYS_INLINE Vc_PURE SSE::schar_v  max(const SSE::schar_v  &x, const SSE::schar_v  &y) { return SSE::max_epi8(x.data(), y.data()); }
+static Vc_ALWAYS_INLINE Vc_PURE SSE::uchar_v  max(const SSE::uchar_v  &x, const SSE::uchar_v  &y) { return _mm_max_epu8(x.data(), y.data()); }
 static Vc_ALWAYS_INLINE Vc_PURE SSE::float_v  max(const SSE::float_v  &x, const SSE::float_v  &y) { return _mm_max_ps(x.data(), y.data()); }
 static Vc_ALWAYS_INLINE Vc_PURE SSE::double_v max(const SSE::double_v &x, const SSE::double_v &y) { return _mm_max_pd(x.data(), y.data()); }
 

--- a/Vc/sse/vector.tcc
+++ b/Vc/sse/vector.tcc
@@ -45,6 +45,8 @@ Vc_INTRINSIC SSE::   int_m operator==(SSE::   int_v a, SSE::   int_v b) { return
 Vc_INTRINSIC SSE::  uint_m operator==(SSE::  uint_v a, SSE::  uint_v b) { return _mm_cmpeq_epi32(a.data(), b.data()); }
 Vc_INTRINSIC SSE:: short_m operator==(SSE:: short_v a, SSE:: short_v b) { return _mm_cmpeq_epi16(a.data(), b.data()); }
 Vc_INTRINSIC SSE::ushort_m operator==(SSE::ushort_v a, SSE::ushort_v b) { return _mm_cmpeq_epi16(a.data(), b.data()); }
+Vc_INTRINSIC SSE::schar_m operator==(SSE:: schar_v a, SSE:: schar_v b) { return _mm_cmpeq_epi8(a.data(), b.data()); }
+Vc_INTRINSIC SSE::uchar_m operator==(SSE::uchar_v a, SSE::uchar_v b) { return _mm_cmpeq_epi8(a.data(), b.data()); }
 
 Vc_INTRINSIC SSE::double_m operator!=(SSE::double_v a, SSE::double_v b) { return _mm_cmpneq_pd(a.data(), b.data()); }
 Vc_INTRINSIC SSE:: float_m operator!=(SSE:: float_v a, SSE:: float_v b) { return _mm_cmpneq_ps(a.data(), b.data()); }
@@ -52,6 +54,8 @@ Vc_INTRINSIC SSE::   int_m operator!=(SSE::   int_v a, SSE::   int_v b) { return
 Vc_INTRINSIC SSE::  uint_m operator!=(SSE::  uint_v a, SSE::  uint_v b) { return not_(_mm_cmpeq_epi32(a.data(), b.data())); }
 Vc_INTRINSIC SSE:: short_m operator!=(SSE:: short_v a, SSE:: short_v b) { return not_(_mm_cmpeq_epi16(a.data(), b.data())); }
 Vc_INTRINSIC SSE::ushort_m operator!=(SSE::ushort_v a, SSE::ushort_v b) { return not_(_mm_cmpeq_epi16(a.data(), b.data())); }
+Vc_INTRINSIC SSE::schar_m operator!=(SSE::schar_v a, SSE::schar_v b) { return not_(_mm_cmpeq_epi8(a.data(), b.data())); }
+Vc_INTRINSIC SSE::uchar_m operator!=(SSE::uchar_v a, SSE::uchar_v b) { return not_(_mm_cmpeq_epi8(a.data(), b.data())); }
 
 Vc_INTRINSIC SSE::double_m operator> (SSE::double_v a, SSE::double_v b) { return _mm_cmpgt_pd(a.data(), b.data()); }
 Vc_INTRINSIC SSE:: float_m operator> (SSE:: float_v a, SSE:: float_v b) { return _mm_cmpgt_ps(a.data(), b.data()); }
@@ -69,6 +73,14 @@ Vc_INTRINSIC SSE::ushort_m operator> (SSE::ushort_v a, SSE::ushort_v b) {
     return SSE::cmpgt_epu16(a.data(), b.data());
 #else
     return _mm_cmpgt_epi16(a.data(), b.data());
+#endif
+}
+Vc_INTRINSIC SSE::schar_m operator> (SSE::schar_v a, SSE::schar_v b) { return _mm_cmpgt_epi8(a.data(), b.data()); }
+Vc_INTRINSIC SSE::uchar_m operator> (SSE::uchar_v a, SSE::uchar_v b) {
+#ifndef USE_INCORRECT_UNSIGNED_COMPARE
+    return SSE::cmpgt_epu8(a.data(), b.data());
+#else
+    return _mm_cmpgt_epi8(a.data(), b.data());
 #endif
 }
 
@@ -90,6 +102,14 @@ Vc_INTRINSIC SSE::ushort_m operator< (SSE::ushort_v a, SSE::ushort_v b) {
     return _mm_cmplt_epi16(a.data(), b.data());
 #endif
 }
+Vc_INTRINSIC SSE::schar_m operator< (SSE::schar_v a, SSE::schar_v b) { return _mm_cmplt_epi8(a.data(), b.data()); }
+Vc_INTRINSIC SSE::uchar_m operator< (SSE::uchar_v a, SSE::uchar_v b) { 
+#ifndef USE_INCORRECT_UNSIGNED_COMPARE
+    return SSE::cmpgt_epu8(b.data(), a.data());
+#else
+    return _mm_cmplt_epi8(a.data(), b.data());
+#endif
+}
 
 Vc_INTRINSIC SSE::double_m operator>=(SSE::double_v a, SSE::double_v b) { return _mm_cmpnlt_pd(a.data(), b.data()); }
 Vc_INTRINSIC SSE:: float_m operator>=(SSE:: float_v a, SSE:: float_v b) { return _mm_cmpnlt_ps(a.data(), b.data()); }
@@ -97,6 +117,8 @@ Vc_INTRINSIC SSE::   int_m operator>=(SSE::   int_v a, SSE::   int_v b) { return
 Vc_INTRINSIC SSE::  uint_m operator>=(SSE::  uint_v a, SSE::  uint_v b) { return !(a < b); }
 Vc_INTRINSIC SSE:: short_m operator>=(SSE:: short_v a, SSE:: short_v b) { return !(a < b); }
 Vc_INTRINSIC SSE::ushort_m operator>=(SSE::ushort_v a, SSE::ushort_v b) { return !(a < b); }
+Vc_INTRINSIC SSE::schar_m operator>=(SSE:: schar_v a, SSE:: schar_v b) { return !(a < b); }
+Vc_INTRINSIC SSE::uchar_m operator>=(SSE:: uchar_v a, SSE:: uchar_v b) { return !(a < b); }
 
 Vc_INTRINSIC SSE::double_m operator<=(SSE::double_v a, SSE::double_v b) { return _mm_cmple_pd(a.data(), b.data()); }
 Vc_INTRINSIC SSE:: float_m operator<=(SSE:: float_v a, SSE:: float_v b) { return _mm_cmple_ps(a.data(), b.data()); }
@@ -104,6 +126,8 @@ Vc_INTRINSIC SSE::   int_m operator<=(SSE::   int_v a, SSE::   int_v b) { return
 Vc_INTRINSIC SSE::  uint_m operator<=(SSE::  uint_v a, SSE::  uint_v b) { return !(a > b); }
 Vc_INTRINSIC SSE:: short_m operator<=(SSE:: short_v a, SSE:: short_v b) { return !(a > b); }
 Vc_INTRINSIC SSE::ushort_m operator<=(SSE::ushort_v a, SSE::ushort_v b) { return !(a > b); }
+Vc_INTRINSIC SSE::schar_m operator<=(SSE:: schar_v a, SSE:: schar_v b) { return !(a > b); }
+Vc_INTRINSIC SSE::uchar_m operator<=(SSE:: uchar_v a, SSE:: uchar_v b) { return !(a > b); }
 
 // bitwise operators {{{1
 template <typename T>
@@ -640,6 +664,10 @@ template <> Vc_INTRINSIC  SSE::short_v  SSE::short_v::interleaveLow ( SSE::short
 template <> Vc_INTRINSIC  SSE::short_v  SSE::short_v::interleaveHigh( SSE::short_v x) const { return _mm_unpackhi_epi16(data(), x.data()); }
 template <> Vc_INTRINSIC SSE::ushort_v SSE::ushort_v::interleaveLow (SSE::ushort_v x) const { return _mm_unpacklo_epi16(data(), x.data()); }
 template <> Vc_INTRINSIC SSE::ushort_v SSE::ushort_v::interleaveHigh(SSE::ushort_v x) const { return _mm_unpackhi_epi16(data(), x.data()); }
+template <> Vc_INTRINSIC  SSE::schar_v  SSE::schar_v::interleaveLow ( SSE::schar_v x) const { return _mm_unpacklo_epi8(data(), x.data()); }
+template <> Vc_INTRINSIC  SSE::schar_v  SSE::schar_v::interleaveHigh( SSE::schar_v x) const { return _mm_unpackhi_epi8(data(), x.data()); }
+template <> Vc_INTRINSIC SSE::uchar_v SSE::uchar_v::interleaveLow (SSE::uchar_v x) const { return _mm_unpacklo_epi8(data(), x.data()); }
+template <> Vc_INTRINSIC SSE::uchar_v SSE::uchar_v::interleaveHigh(SSE::uchar_v x) const { return _mm_unpackhi_epi8(data(), x.data()); }
 // }}}1
 // generate {{{1
 template <> template <typename G> Vc_INTRINSIC SSE::double_v SSE::double_v::generate(G gen)

--- a/src/const.cpp
+++ b/src/const.cpp
@@ -278,6 +278,7 @@ namespace SSE
 
     // cacheline 2
     alignas(16) extern const unsigned int   _IndexesFromZero4[4] = { 0, 1, 2, 3 };
+    alignas(16) const unsigned char c_general::one8[16] = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1};
     alignas(16) const unsigned short c_general::one16[8] = { 1, 1, 1, 1, 1, 1, 1, 1 };
     alignas(16) const unsigned int c_general::one32[4] = { 1, 1, 1, 1 };
     alignas(16) const float c_general::oneFloat[4] = { 1.f, 1.f, 1.f, 1.f };


### PR DESCRIPTION
Hi, porting a project over from the now defunct boost::simd proposal and found that a few things were missing. 

Overall the pull consist of the following:
- added aliases for 8bit vector types in SSE/AVX headers
- added missing min/max functions for 8bit vector types in SSE/AVX code paths
- moves math related functions from vector to math header in SSE (to make it more consistent with AVX organization) 

Cheers