### PR TITLE
Fix alignment of test structs

### DIFF
--- a/tests/gather.cpp
+++ b/tests/gather.cpp
@@ -166,8 +166,8 @@ TEST_TYPES(Vec, gatherArray, ALL_TYPES)
     gatherArrayImpl<Vec, double>();
 }
 
-template<typename T>
-struct alignas(std::is_arithmetic<T>::value ? sizeof(T) : alignof(T)) Struct
+template <typename T, size_t Align = std::is_arithmetic<T>::value ? sizeof(T) : alignof(T)>
+struct alignas(Align > alignof(short) ? Align : alignof(short)) Struct
 {
     T a;
     char x;

--- a/tests/scatter.cpp
+++ b/tests/scatter.cpp
@@ -101,8 +101,8 @@ TEST_TYPES(Vec, maskedScatterArray, AllTypes) //{{{1
 }
 
 //struct Struct {{{1
-template<typename T>
-struct alignas(std::is_arithmetic<T>::value ? sizeof(T) : alignof(T)) Struct
+template <typename T, size_t Align = std::is_arithmetic<T>::value ? sizeof(T) : alignof(T)>
+struct alignas(Align > alignof(short) ? Align : alignof(short)) Struct
 {
     T a;
     char x;

--- a/tests/subscript.cpp
+++ b/tests/subscript.cpp
@@ -164,8 +164,8 @@ TEST_TYPES(V, scatters, AllVectors)
     }
 }
 
-template <typename T>
-struct alignas(std::is_arithmetic<T>::value ? sizeof(T) : alignof(T)) S
+template <typename T, size_t Align = std::is_arithmetic<T>::value ? sizeof(T) : alignof(T)>
+struct alignas(Align > alignof(double) ? Align : alignof(double)) S
 {
     void operator=(int x)
     {


### PR DESCRIPTION
Clang complains for subscript.cpp:
```
error: requested alignment is less than minimum alignment of 8 for type 'S<float>'
```

The reason is that the struct also contains a double that requires
alignment of at least 8 bytes on x86_64 and the program is thus
ill-formed. Remedy by taking `alignof(double)` into account.

Other approaches explored:
1) Adding multiple `alignas`, the compiler should use the "strictest
(largest) non-zero expression". However GCC (including the latest
version 10.2.0) always applies the last attribute and older versions
of Clang (tested: 5.0.2 as in Xcode 9.4.1) also error out.
2) Using `std::max` to get the maximum. GCC complains that the result
is not an integer constant.