### PR TITLE
Disable span<T, dynamic_extent>::_as_bytes() for MSVC

### DIFF
--- a/Vc/common/span.h
+++ b/Vc/common/span.h
@@ -518,6 +518,11 @@ public:
     }
 
 #ifdef __cpp_lib_byte
+// Disable _as_bytes() for MSVC as it leads to a compilation error due to a compiler bug.
+// When parsing the return type, MSVC will instantiate the primary template of span<> and static_assert().
+// A bugreport has been submitted and the issue is supposedly fixed in VS 16.10. If so, we can replace the #ifndef by:
+// #if _MSC_VER > 1928
+#ifndef _MSC_VER
     span<const std::byte, dynamic_extent> _as_bytes() const noexcept
     {
         return {reinterpret_cast<const std::byte*>(data()), size_bytes()};
@@ -527,6 +532,7 @@ public:
     {
         return {reinterpret_cast<std::byte*>(data()), size_bytes()};
     }
+#endif
 #endif  // __cpp_lib_byte
 
 private:


### PR DESCRIPTION
Until MS releases VS 16.10, where they potentially fix this bug, this PR is a workaround for: https://github.com/VcDevel/Vc/issues/239
If VS 16.10 fixes the issue, we can replace the `#ifndef _MSC_VER` by a `#if _MSC_VER > 1928`.

With this change, I can compile a project using Vc and C++17.