### PR TITLE
Fix vector call linking with trigonometric functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ vc-benchmarks
 .makeApidox.stamp
 .makeApidox.stamp.new
 build-*
+.vs
+out

--- a/Vc/common/trigonometric.h
+++ b/Vc/common/trigonometric.h
@@ -63,12 +63,12 @@ namespace Common
 {
 template<typename Impl> struct Trigonometric
 {
-    template<typename T> static T sin(const T &_x);
-    template<typename T> static T cos(const T &_x);
-    template<typename T> static void sincos(const T &_x, T *_sin, T *_cos);
-    template<typename T> static T asin (const T &_x);
-    template<typename T> static T atan (const T &_x);
-    template<typename T> static T atan2(const T &y, const T &x);
+    template<typename T> static T Vc_VDECL sin(const T &_x);
+    template<typename T> static T Vc_VDECL cos(const T &_x);
+    template<typename T> static void Vc_VDECL sincos(const T &_x, T *_sin, T *_cos);
+    template<typename T> static T Vc_VDECL asin (const T &_x);
+    template<typename T> static T Vc_VDECL atan (const T &_x);
+    template<typename T> static T Vc_VDECL atan2(const T &y, const T &x);
 };
 }  // namespace Common
 

--- a/cmake/VcMacros.cmake
+++ b/cmake/VcMacros.cmake
@@ -338,6 +338,7 @@ int main() { return 0; }
          add_definitions(-D_CRT_SECURE_NO_WARNINGS)
       endif()
       vc_add_compiler_flag(Vc_COMPILE_FLAGS "/Gv") # default to __vectorcall
+      vc_add_compiler_flag(Vc_COMPILE_FLAGS "/bigobj") # required for building tests with AVX
 
       if(MSVC_VERSION LESS 1900)
          UserWarning("MSVC before 2015 does not support enough of C++11")


### PR DESCRIPTION
I'm trying to compile Vc with AVX and C++17 on MSVC.
I was getting the same errors as #230 and took the suggestion of #147 to add `__vectorcall` to the right places, at least for the trigonometric functions.