### PR TITLE
Reenable span::_as_bytes() for MSVC > 1928

### DIFF
--- a/Vc/common/span.h
+++ b/Vc/common/span.h
@@ -518,11 +518,9 @@ public:
     }
 
 #ifdef __cpp_lib_byte
-// Disable _as_bytes() for MSVC as it leads to a compilation error due to a compiler bug.
+// Disable _as_bytes() for older MSVC versions as it leads to a compilation error due to a compiler bug.
 // When parsing the return type, MSVC will instantiate the primary template of span<> and static_assert().
-// A bugreport has been submitted and the issue is supposedly fixed in VS 16.10. If so, we can replace the #ifndef by:
-// #if _MSC_VER > 1928
-#ifndef _MSC_VER
+#if _MSC_VER > 1928
     span<const std::byte, dynamic_extent> _as_bytes() const noexcept
     {
         return {reinterpret_cast<const std::byte*>(data()), size_bytes()};


### PR DESCRIPTION
I just revisited #239 with MSVC 1929 / VC 16.10 and it seems the compiler bug is fixed now.
See also the fixed issue on MS' side: https://developercommunity2.visualstudio.com/t/wrong-instantiation-of-primary-template-while-pars/1296700

This PR reenables `span::_as_bytes()` for the corresponding MSVC versions.

Fixed #239.