### PR TITLE
Fix integer comparison warning

### DIFF
--- a/examples/simdize/main.cpp
+++ b/examples/simdize/main.cpp
@@ -40,7 +40,7 @@ public:
 
 private:
     value_type data;
-    int count = 0;
+    std::size_t count = 0;
 };
 
 int Vc_CDECL main()


### PR DESCRIPTION
This PR fixes the following warning: https://cdash.cern.ch/viewBuildError.php?type=1&buildid=94272