### PR TITLE
MSVC: specify Vc_VDECL explicitly on a few functions

### DIFF
--- a/Vc/avx/detail.h
+++ b/Vc/avx/detail.h
@@ -937,7 +937,7 @@ Vc_INTRINSIC __m256i avx_broadcast( uchar x) { return _mm256_set1_epi8(x); }
 // sorted{{{1
 template <Vc::Implementation Impl, typename T,
           typename = enable_if<(Impl >= AVXImpl && Impl <= AVX2Impl)>>
-Vc_CONST_L AVX2::Vector<T> sorted(AVX2::Vector<T> x) Vc_CONST_R;
+Vc_CONST_L AVX2::Vector<T> Vc_VDECL sorted(AVX2::Vector<T> x) Vc_CONST_R;
 template <typename T> Vc_INTRINSIC Vc_CONST AVX2::Vector<T> sorted(AVX2::Vector<T> x)
 {
     return sorted<CurrentImplementation::current()>(x);

--- a/Vc/cpuid.h
+++ b/Vc/cpuid.h
@@ -67,7 +67,7 @@ class CpuId
          * Will be executed automatically before main, but not necessarily before other functions
          * executing before main.
          */
-        static void init();
+        static void Vc_VDECL init();
 
         //! Return the cache line size in bits.
         static inline ushort cacheLineSize() { return static_cast<ushort>(s_cacheLineSize) * 8u; }

--- a/Vc/sse/detail.h
+++ b/Vc/sse/detail.h
@@ -772,7 +772,7 @@ Vc_INTRINSIC  uchar max(__m128i a,  uchar) {
 
 // sorted{{{1
 template <Vc::Implementation, typename T>
-Vc_CONST_L SSE::Vector<T> sorted(SSE::Vector<T> x) Vc_CONST_R;
+Vc_CONST_L SSE::Vector<T> Vc_VDECL sorted(SSE::Vector<T> x) Vc_CONST_R;
 template <typename T> Vc_INTRINSIC Vc_CONST SSE::Vector<T> sorted(SSE::Vector<T> x)
 {
     static_assert(!CurrentImplementation::is(ScalarImpl),

--- a/Vc/support.h
+++ b/Vc/support.h
@@ -72,8 +72,7 @@ unsigned int extraInstructionsSupported();
  *
  * \param impl The SIMD target to test for.
  */
-Vc_TARGET_NO_SIMD
-bool isImplementationSupported(Vc::Implementation impl);
+Vc_TARGET_NO_SIMD bool Vc_VDECL isImplementationSupported(Vc::Implementation impl);
 
 /**
  * \internal


### PR DESCRIPTION
👋 

This MR fixes #289 by making `__vectorcall` visible in the headers. I don't know why MSVC does choose that calling convention by default, though; in Krita, the author of our MSVC support (@ramin-raeisi) went with `Vc_CDECL`, which works equally OK.