### PR TITLE
Treat GitHub Actions CI like travis/appveyor CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -67,13 +67,10 @@ jobs:
 
   build-windows:
     runs-on: ${{ matrix.os }}
-    env:
-      subset: ${{ matrix.subset }}
-    name: build-${{ matrix.os }}-${{ matrix.subset }}
+    name: build-${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        subset: [sse, avx]
         os: [windows-2016] # , windows-2019
     steps:
     - uses: actions/checkout@v2

--- a/test.cmake
+++ b/test.cmake
@@ -107,10 +107,13 @@ endif()
 # determine the (short) hostname of the build machine
 ################################################################################
 set(travis_os $ENV{TRAVIS_OS_NAME})
+set(github_ci $ENV{GITHUB_ACTIONS})
 if(travis_os)
    set(CTEST_SITE "Travis CI")
 elseif(appveyor)
    set(CTEST_SITE "AppVeyor CI")
+elseif(github_ci)
+   set(CTEST_SITE "GitHub Actions")
 else()
    execute_process(COMMAND hostname -s RESULT_VARIABLE ok OUTPUT_VARIABLE CTEST_SITE ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
    if(NOT ok EQUAL 0)
@@ -434,7 +437,7 @@ macro(go)
       unset(CTEST_NOTES_FILES) # less clutter in ctest -V output
       if(res EQUAL 0)
          set(test_results 0)
-         if(travis_os)
+         if(travis_os OR github_ci)
             set(CTEST_BUILD_COMMAND "${CMAKE_MAKE_PROGRAM} ${MAKE_ARGS}")
             ctest_build(
                BUILD "${CTEST_BINARY_DIRECTORY}"


### PR DESCRIPTION
The problem with the current GitHub CI is that we do not know what instruction set the runners support. `test.cmake` has a detection mechanism for travis, but not for github actions, where it ran a simple CTest build (whatever that does, maybe testing what the host supports itself). On appveyor, a more complicated test setup is used, where CTest is invoked multiple times with different instruction sets, based on the environment variable `subset`. When the #278 was merged, the tests ran in a skylake CPU supporting all instruction sets. Current CI builds like #286 run on a broadwell CPU not supporting all instruction sets, which likely causes CTest to fail to enumerate the test suite.