### PR TITLE
Fix MaskBool initialization on SSE

### DIFF
--- a/Vc/sse/mask.h
+++ b/Vc/sse/mask.h
@@ -222,7 +222,7 @@ private:
     friend reference;
     static Vc_INTRINSIC Vc_PURE value_type get(const Mask &m, int i) noexcept
     {
-        return MaskBool(m.d.m(i));
+        return m.toInt() & (1 << i);
     }
     template <typename U>
     static Vc_INTRINSIC void set(Mask &m, int i,

--- a/tests/mask.cpp
+++ b/tests/mask.cpp
@@ -478,6 +478,17 @@ TEST_TYPES(V, testCompareOperators, AllVectors) /*{{{*/
         VERIFY(!(k2 != k2)) << k << k2;
     }
 }
+
+TEST_TYPES(V, testMaskDefined, AllVectors)
+{
+    V a(1);
+    V b(2);
+    auto r = a < b;
+    auto s = a > b;
+    VERIFY(r[0] == true);
+    VERIFY(s[0] == false);
+}
+
 /*}}}*/
 
 // vim: foldmethod=marker


### PR DESCRIPTION
Fixes VcDevel/Vc#255 by initializing the mask in the same way as AVX.

Includes a test that will assess the condition if Vc is compiled with `-DCMAKE_CXX_FLAGS=-ffinite-math-only`. (In all other cases it'll always return true, as explained by the reporter.)