### PR TITLE
Add VS2022 to CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -74,7 +74,7 @@ jobs:
       fail-fast: false
       matrix:
         build_type: [Debug, Release]
-        os: [windows-2019]
+        os: [windows-2019, windows-2022]
     steps:
     - uses: actions/checkout@v2
       with:


### PR DESCRIPTION
This PR adds Visual Studio 2022 to the CI.