### PR TITLE
Remove custom offsetof implementation

### DIFF
--- a/Vc/common/macros.h
+++ b/Vc/common/macros.h
@@ -302,12 +302,6 @@ static Vc_INTRINSIC void unreachable() { __assume(0); }
 
 #define Vc_make_unique(name) Vc_CAT(Vc_,name,_,__LINE__)
 
-#if defined(Vc_ICC) || defined(Vc_CLANG) || defined Vc_APPLECLANG
-#define Vc_OFFSETOF(Type, member) (reinterpret_cast<const char *>(&reinterpret_cast<const Type *>(0)->member) - reinterpret_cast<const char *>(0))
-#else
-#define Vc_OFFSETOF(Type, member) offsetof(Type, member)
-#endif
-
 #if defined(Vc_NO_NOEXCEPT)
 #define Vc_NOEXCEPT throw()
 #else

--- a/Vc/common/memory.h
+++ b/Vc/common/memory.h
@@ -296,7 +296,7 @@ class Memory<V, Size, 0u, InitPadding> :
                 // accordingly
                 char *addr = reinterpret_cast<char *>(ptr);
                 typedef Memory<V, Size, 0u, false> MM;
-                addr -= Vc_OFFSETOF(MM, m_mem);
+                addr -= offsetof(MM, m_mem);
                 return *new(addr) MM;
             }
 


### PR DESCRIPTION
Clang complains that "performing pointer subtraction with a null pointer may have undefined behavior" and the whole code path doesn't seem to be necessary anymore with current compilers.