### PR TITLE
Fix zen3 flags for icc and support icelake

### DIFF
--- a/cmake/OptimizeForArchitecture.cmake
+++ b/cmake/OptimizeForArchitecture.cmake
@@ -521,8 +521,9 @@ Other supported values are: \"none\", \"generic\", \"core\", \"merom\" (65nm Cor
          set(OFA_map_penryn "-xSSSE3")
          set(OFA_map_merom "-xSSSE3")
          set(OFA_map_core2 "-xSSE3")
-         set(OFA_map_zen3 "-xAVX2")
-         set(OFA_map_zen "-xAVX2")
+         set(OFA_map_znver3 "-mavx2") # -xAVX2 does not work and causes this runtime check to appear:
+         set(OFA_map_znver2 "-mavx2") # Please verify that both the operating system and the processor support Intel(R) X87, CMOV, MMX, FXSAVE, SSE, SSE2, SSE3, SSSE3, SSE4_1, SSE4_2, MOVBE, POPCNT, AVX, F16C, FMA, BMI, LZCNT and AVX2 instructions.
+         set(OFA_map_znver1 "-mavx2")
          set(_ok FALSE)
          foreach(arch ${_march_flag_list})
             if(DEFINED OFA_map_${arch})

--- a/cmake/OptimizeForArchitecture.cmake
+++ b/cmake/OptimizeForArchitecture.cmake
@@ -130,16 +130,18 @@ macro(AutodetectHostArchitecture)
          # 4E | Skylake Client
          # 3C | Broadwell (likely a bug in the SDE)
          # 3C | Haswell
-         if(_cpu_model EQUAL 87) # 57
+         if(_cpu_model EQUAL 142 OR _cpu_model EQUAL 158) # 8E, 9E
+            set(TARGET_ARCHITECTURE "kaby-lake")
+         elseif(_cpu_model EQUAL 106)
+            set(TARGET_ARCHITECTURE "icelake")
+         elseif(_cpu_model EQUAL 102)
+            set(TARGET_ARCHITECTURE "cannonlake")
+         elseif(_cpu_model EQUAL 87) # 57
             set(TARGET_ARCHITECTURE "knl")  # Knights Landing
          elseif(_cpu_model EQUAL 92)
             set(TARGET_ARCHITECTURE "goldmont")
          elseif(_cpu_model EQUAL 90 OR _cpu_model EQUAL 76)
             set(TARGET_ARCHITECTURE "silvermont")
-         elseif(_cpu_model EQUAL 102)
-            set(TARGET_ARCHITECTURE "cannonlake")
-         elseif(_cpu_model EQUAL 142 OR _cpu_model EQUAL 158) # 8E, 9E
-            set(TARGET_ARCHITECTURE "kaby-lake")
          elseif(_cpu_model EQUAL 85) # 55
             set(TARGET_ARCHITECTURE "skylake-avx512")
          elseif(_cpu_model EQUAL 78 OR _cpu_model EQUAL 94) # 4E, 5E
@@ -225,7 +227,7 @@ Using an incorrect setting here can result in crashes of the resulting binary be
 Setting the value to \"auto\" will try to optimize for the architecture where cmake is called. \
 Other supported values are: \"none\", \"generic\", \"core\", \"merom\" (65nm Core2), \
 \"penryn\" (45nm Core2), \"nehalem\", \"westmere\", \"sandy-bridge\", \"ivy-bridge\", \
-\"haswell\", \"broadwell\", \"skylake\", \"skylake-xeon\", \"kaby-lake\", \"cannonlake\", \"silvermont\", \
+\"haswell\", \"broadwell\", \"skylake\", \"skylake-xeon\", \"kaby-lake\", \"cannonlake\", \"icelake\", \"silvermont\", \
 \"goldmont\", \"knl\" (Knights Landing), \"atom\", \"k8\", \"k8-sse3\", \"barcelona\", \
 \"istanbul\", \"magny-cours\", \"bulldozer\", \"interlagos\", \"piledriver\", \
 \"AMD 14h\", \"AMD 16h\", \"zen\", \"zen3\".")
@@ -327,6 +329,8 @@ Other supported values are: \"none\", \"generic\", \"core\", \"merom\" (65nm Cor
       endif()
    elseif(TARGET_ARCHITECTURE STREQUAL "knl")
       _knightslanding()
+   elseif(TARGET_ARCHITECTURE STREQUAL "icelake")
+      _cannonlake()
    elseif(TARGET_ARCHITECTURE STREQUAL "cannonlake")
       _cannonlake()
    elseif(TARGET_ARCHITECTURE STREQUAL "kaby-lake")
@@ -509,6 +513,7 @@ Other supported values are: \"none\", \"generic\", \"core\", \"merom\" (65nm Cor
          endforeach(_flag)
       elseif(CMAKE_CXX_COMPILER MATCHES "/(icpc|icc)$") # ICC (on Linux)
          set(OFA_map_knl "-xMIC-AVX512")
+         set(OFA_map_icelake "-xCORE-AVX512")
          set(OFA_map_cannonlake "-xCORE-AVX512")
          set(OFA_map_skylake-avx512 "-xCORE-AVX512")
          set(OFA_map_skylake "-xCORE-AVX2")

--- a/cmake/VcMacros.cmake
+++ b/cmake/VcMacros.cmake
@@ -495,7 +495,7 @@ macro(vc_compile_for_all_implementations _srcs _src)
       # which case AVX2 implies the availability of FMA and BMI2
       #_vc_compile_one_implementation(${_srcs} AVX2  "-mavx2")
       #_vc_compile_one_implementation(${_srcs} AVX2+BMI2 "-mavx2 -mbmi2")
-      _vc_compile_one_implementation(${_srcs} AVX2+FMA+BMI2 "-xCORE-AVX2" "-mavx2 -mfma -mbmi2" "/arch:AVX2")
+      _vc_compile_one_implementation(${_srcs} AVX2+FMA+BMI2 "-xAVX2" "-mavx2 -mfma -mbmi2" "/arch:AVX2")
       #_vc_compile_one_implementation(${_srcs} AVX2+FMA "-mavx2 -mfma")
    endif()
    list(LENGTH _only_targets _len)


### PR DESCRIPTION
This PR fixes the flags passed to icc, when a zen3 CPU was detected. It furthermore let's icc build the AVX2 Vc static library without Intel specific instruction sets. To make the CI pass, also support for icelake CPUs had to be cherry-picked from #319.