### PR TITLE
Make godbolt headers have all of Vc

### DIFF
--- a/prepare_single_header.sh
+++ b/prepare_single_header.sh
@@ -7,12 +7,6 @@ seen=()
 parse_file() {
   dir=${1%/*}
   file=${1##*/}
-  case "$file" in
-    memory.h) return;;
-    memorybase.h) return;;
-    *deprecated*) return;;
-    *debug.h) return;;
-  esac
   [[ "$1" =~ "/" ]] && pushd "$dir"
   #echo "${seen[@]}"
   if [[ "$PWD/$file" = ${(~j.|.)seen} ]]; then


### PR DESCRIPTION
This PR removes the exclusion of some files when generating the headers for compiler explorer.