### PR TITLE
Fix out of bounds index when float_v is scalar

### DIFF
--- a/tests/casts.cpp
+++ b/tests/casts.cpp
@@ -393,25 +393,13 @@ TEST(fullConversion)/*{{{*/
 }/*}}}*/
 #endif // Vc_DEFAULT_TYPES
 
-TEST(referenceConstruction)
+TEST_TYPES(V, referenceConstruction, AllTypes)
 {
-    float_v a = float_v::Random();
+    V a = V::Random();
+    V r(a[0]);
 
-    Vc::float_v r(a[2]);
-
-    for (size_t i = 0; i < float_v::Size; ++i) {
-        COMPARE(r[i], static_cast<float>(a[2])) << "i = " << i;
-    }
-}
-
-TEST(referenceConstructionSimdArray)
-{
-    float_v a = float_v::Random();
-
-    Vc::SimdArray<float, Vc::float_v::size()> r2(a[2]);
-
-    for (size_t i = 0; i < float_v::Size; ++i) {
-        COMPARE(r2[i], static_cast<float>(a[2])) << "i = " << i;
+    for (size_t i = 0; i < V::Size; ++i) {
+        COMPARE(r[i], static_cast<float>(a[0])) << "i = " << i;
     }
 }
 


### PR DESCRIPTION
This fixes an out of bounds access in the unit tests when `float_v` is scalar. It also runs the unit test on all vector types.