### PR TITLE
Add missing vectorcall to isImplementationSupported

### DIFF
--- a/src/support_x86.cpp
+++ b/src/support_x86.cpp
@@ -59,7 +59,7 @@ static inline bool xgetbvCheck(unsigned int bits)
 }
 
 Vc_TARGET_NO_SIMD
-bool isImplementationSupported(Implementation impl)
+bool Vc_VDECL isImplementationSupported(Implementation impl)
 {
     CpuId::init();
 


### PR DESCRIPTION
This fixes a downstream build failure with vcpkg for triplet x64-uwp.
See PR: https://github.com/microsoft/vcpkg/pull/24880