### PR TITLE
Small CMake improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 if(PROJECT_SOURCE_DIR STREQUAL PROJECT_BINARY_DIR)
    message(FATAL_ERROR "You don't want to configure in the source directory!")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,5 @@
 cmake_minimum_required(VERSION 3.0)
 
-cmake_policy(SET CMP0028 NEW) # Double colon in target name means ALIAS or IMPORTED target.
-cmake_policy(SET CMP0048 NEW) # The ``project()`` command manages VERSION variables.
-
 if(PROJECT_SOURCE_DIR STREQUAL PROJECT_BINARY_DIR)
    message(FATAL_ERROR "You don't want to configure in the source directory!")
 endif()

--- a/cmake/VcMacros.cmake
+++ b/cmake/VcMacros.cmake
@@ -52,7 +52,7 @@ macro(vc_determine_compiler)
          exec_program(${CMAKE_CXX_COMPILER} ARGS -dumpversion OUTPUT_VARIABLE Vc_ICC_VERSION)
          message(STATUS "Detected Compiler: Intel ${Vc_ICC_VERSION}")
 
-         # break build with too old clang as early as possible.
+         # break build with too old ICC as early as possible.
          if(Vc_ICC_VERSION VERSION_LESS 18.0.0)
             message(FATAL_ERROR "Vc 1.4 requires least ICC 18")
          endif()

--- a/cmake/VcMacros.cmake
+++ b/cmake/VcMacros.cmake
@@ -32,7 +32,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #=============================================================================
 
-cmake_minimum_required(VERSION 2.8.3...3.13)
+cmake_minimum_required(VERSION 3.5...3.13)
 
 get_filename_component(_currentDir "${CMAKE_CURRENT_LIST_FILE}" PATH)
 include ("${_currentDir}/UserWarning.cmake")


### PR DESCRIPTION
Set minimum required CMake version to 3.5 to prevent warning.
Remove explicit CMake policies that are set to NEW by CMake 3.0.